### PR TITLE
fix logic to read Fabric API Key

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
     buildToolsVersion "23.0.1"
 
     Properties properties = new Properties()
-    properties.load(project.rootProject.file('local.properties').newDataInputStream())
+    properties.load(project.rootProject.file('app/fabric.properties').newDataInputStream())
 
     defaultConfig {
         applicationId "chat.rocket.android"
@@ -22,7 +22,7 @@ android {
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"
-        manifestPlaceholders = [fabric_api_key:properties.getProperty("FABRIC_API_KEY", System.getenv("FABRIC_API_KEY"))]
+        manifestPlaceholders = [fabric_api_key:properties.getProperty("apiKey", System.getenv("FABRIC_API_KEY"))]
         ext.betaDistributionNotifications=false
         ext.betaDistributionReleaseNotes=getCurrentCommitMessage()
     }


### PR DESCRIPTION
### before

 app/build.gradle read FABRIC_API_KEY from local.properties
 crashlytics SDK internally read Fabric API Key from app/fabric.properties
### after

 app/build.gradle read 'apiKey' **from app/fabric.properties**
 crashlytics SDK internally read Fabric API Key from app/fabric.properties
