### PR TITLE
'attachment' support (fixes issue #11)

### DIFF
--- a/app/src/main/java/chat/rocket/android/activity/MainActivity.java
+++ b/app/src/main/java/chat/rocket/android/activity/MainActivity.java
@@ -485,7 +485,7 @@ public class MainActivity extends AbstractActivity {
             }
 
             getSupportFragmentManager().beginTransaction()
-                    .replace(getContainerId(), ChatRoomFragment.create(s.hostname, r))
+                    .replace(getContainerId(), ChatRoomFragment.create(s.hostname, s.authToken, r))
                     .commit();
         }
     }

--- a/app/src/main/java/chat/rocket/android/api/JSONParseEngine.java
+++ b/app/src/main/java/chat/rocket/android/api/JSONParseEngine.java
@@ -31,9 +31,14 @@ public class JSONParseEngine {
             m.id = messageId;
         }
         m.roomId = message.getString("rid");
-        m.content = message.getString("msg");
+        if (!message.isNull("msg")) m.content = message.getString("msg");
         m.timestamp = message.getJSONObject("ts").getLong("$date");
         m.type = Message.Type.getType(message.isNull("t")? "" : message.getString("t"));
+
+        if (!message.isNull("groupable")) {
+            if (message.getBoolean("groupable")) m.flags |= Message.FLAG_GROUPABLE;
+            else m.flags &= ~Message.FLAG_GROUPABLE;
+        }
 
         final JSONObject user = message.getJSONObject("u");
         final String userId = user.getString("_id");
@@ -63,6 +68,10 @@ public class JSONParseEngine {
             m.urls = message.getJSONArray("urls").toString();
         }
         else m.urls = "[]";
+        if(!message.isNull("attachments")) {
+            m.attachments = message.getJSONArray("attachments").toString();
+        }
+        else m.attachments = "[]";
         m.extras = "{}";
         m.putByContentProvider(mContext);
     }

--- a/app/src/main/java/chat/rocket/android/api/ws/RocketChatWSAPI.java
+++ b/app/src/main/java/chat/rocket/android/api/ws/RocketChatWSAPI.java
@@ -79,12 +79,16 @@ public class RocketChatWSAPI {
         return mDDPClient.rpc("logout",null,generateId("logout"));
     }
 
-    public Task<DDPClientCallback.RPC> sendMessage(final String roomId, String msg, @Nullable  JSONObject fileDoc) throws JSONException {
+    public Task<DDPClientCallback.RPC> sendMessage(final String roomId, String msg, @Nullable  JSONObject extraParams) throws JSONException {
         JSONObject param = new JSONObject()
                 .put("_id", generateId("message-doc"))
                 .put("rid", roomId)
                 .put("msg", msg);
-        if(fileDoc!=null) param.put("file", fileDoc);
+        if(extraParams!=null) {
+            if(!extraParams.isNull("file")) param.put("file", extraParams.getJSONObject("file"));
+            if(!extraParams.isNull("groupable")) param.put("groupable", extraParams.getBoolean("groupable"));
+            if(!extraParams.isNull("attachments")) param.put("attachments", extraParams.getJSONArray("attachments"));
+        }
 
         return mDDPClient.rpc("sendMessage", new JSONArray().put(param) ,generateId("message"));
     }

--- a/app/src/main/java/chat/rocket/android/content/RocketChatDatabaseHelper.java
+++ b/app/src/main/java/chat/rocket/android/content/RocketChatDatabaseHelper.java
@@ -15,7 +15,7 @@ import chat.rocket.android.model.UserRoom;
 public class RocketChatDatabaseHelper extends SQLiteOpenHelper {
     private static final String TAG = Constants.LOG_TAG;
     private static final String DB_NAME="rockets.db";
-    static final int DB_VERSION=3;
+    static final int DB_VERSION=4;
 
     public RocketChatDatabaseHelper(Context context) {
         super(context, DB_NAME, null, DB_VERSION);

--- a/app/src/main/java/chat/rocket/android/content/observer/SendNewMessageHandler.java
+++ b/app/src/main/java/chat/rocket/android/content/observer/SendNewMessageHandler.java
@@ -7,6 +7,7 @@ import android.os.Looper;
 import android.text.TextUtils;
 import android.util.Log;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -49,10 +50,14 @@ public class SendNewMessageHandler extends AbstractObserver {
         m.putByContentProvider(mContext);
 
         try {
-            JSONObject fileDoc = null;
+            JSONObject params = new JSONObject();
             JSONObject extras = TextUtils.isEmpty(m.extras)? new JSONObject() : new JSONObject(m.extras);
-            if(!extras.isNull("file")) fileDoc = extras.getJSONObject("file");
-            mAPI.sendMessage(m.roomId, m.content, fileDoc).continueWith(new Continuation<DDPClientCallback.RPC, Object>() {
+
+            if(!extras.isNull("file")) params.put("file", extras.getJSONObject("file"));
+            if(!m.isGroupable()) params.put("groupable", false);
+            if(!TextUtils.isEmpty(m.attachments)) params.put("attachments", new JSONArray(m.attachments));
+
+            mAPI.sendMessage(m.roomId, m.content, params).continueWith(new Continuation<DDPClientCallback.RPC, Object>() {
                 @Override
                 public Object then(Task<DDPClientCallback.RPC> task) throws Exception {
                     JSONObject result = task.getResult().result;

--- a/app/src/main/java/chat/rocket/android/fragment/ChatRoomFragment.java
+++ b/app/src/main/java/chat/rocket/android/fragment/ChatRoomFragment.java
@@ -100,7 +100,8 @@ public class ChatRoomFragment extends AbstractFragment implements OnBackPressLis
             mInterceptor = new Interceptor() {
                 @Override
                 public Response intercept(Chain chain) throws IOException {
-
+                    // uid/token is required to download attachment files.
+                    // see: RocketChat:lib/fileUpload.coffee
                     Request newRequest = chain.request().newBuilder()
                             .header("Cookie", "rc_uid="+mUserId+";rc_token="+mToken)
                             .build();
@@ -958,12 +959,21 @@ public class ChatRoomFragment extends AbstractFragment implements OnBackPressLis
                                 JSONObject ret = new JSONObject(m.returns);
                                 dialog.setProgress(100);
 
+                                JSONObject attachment = new JSONObject()
+                                        .put("title","File Uploaded: "+ret.getString("name"))
+                                        .put("title_url",ret.getString("url"))
+                                        .put("image_url",ret.getString("url"))
+                                        .put("image_type",ret.getString("type"))
+                                        .put("image_size",ret.getLong("size"));
+
                                 Message msg = new Message();
                                 msg.syncstate = SyncState.NOT_SYNCED;
-                                msg.content = "File Uploaded: *"+ret.getString("name")+"*\n"+ret.getString("url");
+                                msg.content = "";
                                 msg.roomId = ret.getString("rid");
                                 msg.userId = ret.getString("userID");
                                 msg.extras = new JSONObject().put("file",new JSONObject().put("_id",ret.getString("_id"))).toString();
+                                msg.flags &= ~Message.FLAG_GROUPABLE;
+                                msg.attachments = new JSONArray().put(attachment).toString();
                                 msg.putByContentProvider(getContext());
 
                             }

--- a/app/src/main/java/chat/rocket/android/model/Message.java
+++ b/app/src/main/java/chat/rocket/android/model/Message.java
@@ -87,7 +87,31 @@ public class Message extends AbstractModel{
      *
      */
     public String urls;
+
+    /**
+     *  "attachments": [{
+     *      "title": "File Uploaded: twitterYI01.jpg",
+     *      "title_link": "/ufs/rocketchat_uploads/pi6pnxHqPQNG6kyPz/twitterYI01.jpg",
+     *      "image_url": "/ufs/rocketchat_uploads/pi6pnxHqPQNG6kyPz/twitterYI01.jpg",
+     *      "image_type": "image/jpeg",
+     *      "image_size": 6105
+     *  }]
+     */
+    public String attachments;
+
+    /**
+     * for storeing
+     *
+     * * fileID for uploading file.
+     */
     public String extras;
+
+    public int flags;
+    public static final int FLAG_GROUPABLE = 0x00000001;
+
+    public boolean isGroupable() {
+        return (flags & FLAG_GROUPABLE) == FLAG_GROUPABLE;
+    }
 
     @Override
     public String getTableName() {
@@ -109,7 +133,7 @@ public class Message extends AbstractModel{
         protected void updateTable(int oldVersion, int newVersion) {
             int updateVersion = oldVersion;
 
-            if (updateVersion < 2) {
+            if (updateVersion < 4) {
                 mDb.beginTransaction();
                 try {
                     dropTable();
@@ -123,7 +147,9 @@ public class Message extends AbstractModel{
                             " content TEXT," +
                             " timestamp INTEGER," +
                             " urls TEXT," +
-                            " extras TEXT);");
+                            " attachments TEXT," +
+                            " extras TEXT," +
+                            " flags INTEGER);");
 
                     mDb.setTransactionSuccessful();
                 }
@@ -131,7 +157,7 @@ public class Message extends AbstractModel{
                     mDb.endTransaction();
                 }
 
-                updateVersion = 2;
+                updateVersion = 4;
             }
         }
     }
@@ -145,7 +171,9 @@ public class Message extends AbstractModel{
         m.content = c.getString(c.getColumnIndex("content"));
         m.timestamp = c.getLong(c.getColumnIndex("timestamp"));
         m.urls = c.getString(c.getColumnIndex("urls"));
+        m.attachments = c.getString(c.getColumnIndex("attachments"));
         m.extras = c.getString(c.getColumnIndex("extras"));
+        m.flags = c.getInt(c.getColumnIndex("flags"));
         return m;
     }
 
@@ -158,7 +186,9 @@ public class Message extends AbstractModel{
         values.put("content", content);
         values.put("timestamp", timestamp);
         values.put("urls", urls);
+        values.put("attachments", attachments);
         values.put("extras", extras);
+        values.put("flags", flags);
         return values;
     }
 

--- a/app/src/main/res/layout/listitem_inline_attachment.xml
+++ b/app/src/main/res/layout/listitem_inline_attachment.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/list_item_inline_image_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:layout_margin="4dp"
+    android:padding="4dp"
+    android:theme="@style/Theme.AppCompat.Light">
+    <View
+        android:layout_width="3dp"
+        android:layout_height="match_parent"
+        android:layout_marginRight="5dp"
+        android:background="#FFCCCCCC"/>
+
+    <LinearLayout
+        android:layout_width="0px"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/inline_attachment_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:layout_marginBottom="2dp"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:textColor="@color/colorAccent"/>
+
+        <ImageView
+            android:id="@+id/inline_attachment_image"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxHeight="200dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginRight="@dimen/margin_half"
+            android:adjustViewBounds="true"
+            android:scaleType="fitStart"/>
+
+    </LinearLayout>
+
+</LinearLayout>


### PR DESCRIPTION
The 'attachments' field is intruduced by https://github.com/RocketChat/Rocket.Chat/commit/441ae0b552340b45548b416dcbf29536ac925749, and uploading file feature now uses it.

Android-Lily doesn't use WebView, so we have to catch up with it with our own effort.

![image](https://cloud.githubusercontent.com/assets/11763113/12014461/7ef97d28-ad70-11e5-9cee-888e58c549ba.png)
