### PR TITLE
gradlew assembleDebug throws autolink library not found - fixed

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,4 +81,5 @@ dependencies {
     }
 
     compile 'io.repro:repro-android-sdk:0.12.0'
+    compile 'org.nibor.autolink:autolink:0.5.0'
 }


### PR DESCRIPTION
org.nibor.autolink library was missing. Build was failing.
