### PR TITLE
gradlew assembleDebug throws autolink library not found - fixed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "autolink-java"]
-	path = autolink-java
-	url = https://github.com/YusukeIwaki/autolink-java.git

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,4 +81,5 @@ dependencies {
     }
 
     compile 'io.repro:repro-android-sdk:0.12.0'
+    compile 'org.nibor.autolink:autolink:0.5.0'
 }


### PR DESCRIPTION
Created as per https://github.com/RocketChat/Rocket.Chat.Android.Lily/issues/28
