### PR TITLE
Fix circleci build error 20160911

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,8 +33,6 @@ android {
         manifestPlaceholders = [fabric_api_key:properties.getProperty("apiKey", System.getenv("FABRIC_API_KEY"))]
         ext.betaDistributionNotifications=false
         ext.betaDistributionReleaseNotes=getCurrentCommitMessage()
-
-       // buildConfigField "String", "REPRO_APP_TOKEN", localprop.getProperty("REPRO_APP_TOKEN", System.getenv("REPRO_APP_TOKEN"))
     }
     signingConfigs {
         release {
@@ -80,6 +78,5 @@ dependencies {
         transitive = true
     }
 
-    compile 'io.repro:repro-android-sdk:0.12.0'
     compile 'org.nibor.autolink:autolink:0.5.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ def getKeyStore() {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 24
+    buildToolsVersion "24.0.0"
 
     Properties properties = new Properties()
     properties.load(project.rootProject.file('app/fabric.properties').newDataInputStream())
@@ -27,7 +27,7 @@ android {
     defaultConfig {
         applicationId "chat.rocket.android"
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 1
         versionName "0.0.0"
         manifestPlaceholders = [fabric_api_key:properties.getProperty("apiKey", System.getenv("FABRIC_API_KEY"))]
@@ -60,8 +60,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.android.support:design:23.1.1'
+    compile 'com.android.support:appcompat-v7:24.2.0'
+    compile 'com.android.support:design:24.2.0'
 
     compile 'com.github.clans:fab:1.6.2'
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,11 +36,6 @@
         <meta-data
             android:name="io.fabric.ApiKey"
             android:value="${fabric_api_key}" />
-
-        <service android:name="io.repro.android.ReproService" />
-        <activity
-            android:name="io.repro.android.surveys.SurveyActivity"
-            android:theme="@style/io_repro_android_SurveyActivityTheme"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/chat/rocket/android/RocketChatApplication.java
+++ b/app/src/main/java/chat/rocket/android/RocketChatApplication.java
@@ -10,7 +10,6 @@ import com.squareup.picasso.Picasso;
 
 import chat.rocket.android.api.OkHttpHelper;
 import io.fabric.sdk.android.Fabric;
-import io.repro.android.Repro;
 
 public class RocketChatApplication extends Application {
     @Override
@@ -28,6 +27,5 @@ public class RocketChatApplication extends Application {
 
         CrashlyticsCore core = new CrashlyticsCore.Builder().disabled(BuildConfig.DEBUG).build();
         Fabric.with(this, new Crashlytics.Builder().core(core).build());
-        Repro.setup(BuildConfig.REPRO_APP_TOKEN);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ allprojects {
     repositories {
         jcenter()
         maven { url 'https://maven.fabric.io/public' }
-        maven { url 'http://cdn.repro.io/android' }
         maven { url 'https://github.com/RocketChat/Android-DDP/raw/master/repository' } // for Android-DDP
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 21 11:34:03 PDT 2015
+#Sun Sep 11 16:04:15 JST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
- Remove Repro SDK.
  it is useful. But not suitable to use just now.
