### PR TITLE
FIX #50 fix the behavior of back-press on SlidingPane is opened.

### DIFF
--- a/app/src/main/java/chat/rocket/android/activity/MainActivity.java
+++ b/app/src/main/java/chat/rocket/android/activity/MainActivity.java
@@ -49,12 +49,14 @@ public class MainActivity extends AbstractAuthedActivity {
     }
   }
 
-  private void closeSidebarIfNeeded() {
+  private boolean closeSidebarIfNeeded() {
     // REMARK: Tablet UI doesn't have SlidingPane!
     SlidingPaneLayout pane = (SlidingPaneLayout) findViewById(R.id.sliding_pane);
-    if (pane != null) {
+    if (pane != null && pane.isOpen()) {
       pane.closePane();
+      return true;
     }
+    return false;
   }
 
   @DebugLog
@@ -105,5 +107,7 @@ public class MainActivity extends AbstractAuthedActivity {
     }
   }
 
-
+  @Override protected boolean onBackPress() {
+    return closeSidebarIfNeeded() || super.onBackPress();
+  }
 }


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #50

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

The logic for handling Back-key in MainActivity was:

1.  If fragment handles it, consumed.
2.  otherwise; close Activity.

Now it will be:

1.  **close SlidingPane if possble with consume.**
2.  If not, if fragment handles it, consume.
3.  otherwise; close Activity.
