### PR TITLE
Hide closed subscriptions from drawer

### DIFF
--- a/app/src/main/java/chat/rocket/android/fragment/sidebar/SidebarMainFragment.java
+++ b/app/src/main/java/chat/rocket/android/fragment/sidebar/SidebarMainFragment.java
@@ -63,7 +63,7 @@ public class SidebarMainFragment extends AbstractFragment {
       RealmHelper realmHelper = RealmStore.get(serverConfigId);
       if (realmHelper != null) {
         roomsObserver = realmHelper
-            .createListObserver(realm -> realm.where(RoomSubscription.class).findAll())
+            .createListObserver(realm -> realm.where(RoomSubscription.class).equalTo("open", true).findAll())
             .setOnUpdateListener(list -> roomListManager.setRooms(list));
 
         currentUserObserver = realmHelper


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

Like the web app, this PR hides "closed" subscriptions from the drawer.