### PR TITLE
fix the issue that RealmObjectObserver's callback is called repeatedly

### DIFF
--- a/realm-helpers/src/main/java/chat/rocket/android/realm_helper/RealmListObserver.java
+++ b/realm-helpers/src/main/java/chat/rocket/android/realm_helper/RealmListObserver.java
@@ -30,7 +30,7 @@ public class RealmListObserver<T extends RealmObject> extends AbstractRealmResul
   @Override
   public final RealmChangeListener<RealmResults<T>> getListener() {
     return results -> {
-      String currentResultString = results != null ? results.toString() : null;
+      String currentResultString = results != null ? results.toString() : "null";
       if (previousResultsString != null && previousResultsString.equals(currentResultString)) {
         return;
       }

--- a/realm-helpers/src/main/java/chat/rocket/android/realm_helper/RealmListObserver.java
+++ b/realm-helpers/src/main/java/chat/rocket/android/realm_helper/RealmListObserver.java
@@ -30,7 +30,7 @@ public class RealmListObserver<T extends RealmObject> extends AbstractRealmResul
   @Override
   public final RealmChangeListener<RealmResults<T>> getListener() {
     return results -> {
-      String currentResultString = results != null ? results.toString() : "null";
+      String currentResultString = results != null ? results.toString() : "";
       if (previousResultsString != null && previousResultsString.equals(currentResultString)) {
         return;
       }

--- a/realm-helpers/src/main/java/chat/rocket/android/realm_helper/RealmObjectObserver.java
+++ b/realm-helpers/src/main/java/chat/rocket/android/realm_helper/RealmObjectObserver.java
@@ -37,7 +37,7 @@ public class RealmObjectObserver<T extends RealmObject> extends AbstractRealmRes
   protected final RealmChangeListener<RealmResults<T>> getListener() {
     return element -> {
       T currentResult = impl.extractObjectFromResults(element);
-      String currentResultString = currentResult != null ? currentResult.toString() : null;
+      String currentResultString = currentResult != null ? currentResult.toString() : "null";
       if (previousResultString != null && previousResultString.equals(currentResultString)) {
         return;
       }

--- a/realm-helpers/src/main/java/chat/rocket/android/realm_helper/RealmObjectObserver.java
+++ b/realm-helpers/src/main/java/chat/rocket/android/realm_helper/RealmObjectObserver.java
@@ -37,7 +37,7 @@ public class RealmObjectObserver<T extends RealmObject> extends AbstractRealmRes
   protected final RealmChangeListener<RealmResults<T>> getListener() {
     return element -> {
       T currentResult = impl.extractObjectFromResults(element);
-      String currentResultString = currentResult != null ? currentResult.toString() : "null";
+      String currentResultString = currentResult != null ? currentResult.toString() : "";
       if (previousResultString != null && previousResultString.equals(currentResultString)) {
         return;
       }


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

When the result of the query is null, RealmObjectObserver calls the callback function repeatedly with `null` parameter because

```
      if (previousResultsString != null && previousResultsString.equals(currentResultString)) {
        return;
      }
```

When previousResultsString = null, currentResultString = null,
not returned here...



`previousResultsString != null` is necessary for initial callback. 
So I replaced `currentResultString = null` to ` currentResultString = ""`