### PR TITLE
fix login screen not to be refreshed onResume.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,8 @@
                 android:windowSoftInputMode="adjustResize" />
         <activity
                 android:name=".activity.ServerConfigActivity"
-                android:windowSoftInputMode="adjustResize" />
+                android:windowSoftInputMode="adjustResize"
+                android:configChanges="orientation|screenSize"/>
 
         <service android:name=".service.RocketChatService" />
 

--- a/app/src/main/java/chat/rocket/android/activity/ServerConfigActivity.java
+++ b/app/src/main/java/chat/rocket/android/activity/ServerConfigActivity.java
@@ -60,20 +60,20 @@ public class ServerConfigActivity extends AbstractFragmentActivity {
 
     setContentView(R.layout.simple_screen);
     showFragment(new WaitingFragment());
+    serverConfigErrorObserver.sub();
   }
 
   @Override
   protected void onResume() {
     super.onResume();
     RocketChatService.keepAlive(this);
-    serverConfigErrorObserver.sub();
   }
 
   @Override
-  protected void onPause() {
+  protected void onDestroy() {
     sessionObserver.unsub();
     serverConfigErrorObserver.unsub();
-    super.onPause();
+    super.onDestroy();
   }
 
   private void onRenderServerConfigError(ServerConfig config) {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #76 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

Login screen was refreshed for each time the activity is resumed.
It prevents us from authenticating with 2fa.

Now LoginActivity is not refreshed on resume, even if screen rotation, by setting `configChanges="screenSize|orientation"` and extending the lifecycle of the Realm object listeners.