### PR TITLE
prevent RocketChatService from automatically restarting

### DIFF
--- a/app/src/main/java/chat/rocket/android/service/RocketChatService.java
+++ b/app/src/main/java/chat/rocket/android/service/RocketChatService.java
@@ -95,7 +95,7 @@ public class RocketChatService extends Service {
       connectionRequiredServerConfigObserver.sub();
       return null;
     });
-    return START_STICKY;
+    return START_NOT_STICKY;
   }
 
   private void connectToServerWithServerConfig(List<ServerConfig> configList) {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

RocketChatService is assumed to be triggered each time if needed (ex. after MethodCall record is inserted), and actually unnecessary to be alive with self-restarting.

This PR just turns the flag for RocketChatService to START_NOT_STICKY, and prevent unexpected activation caused by the automatic restart of the service.