### PR TITLE
show budge for unread message count

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,7 +121,7 @@ dependencies {
     compile 'com.trello:rxlifecycle-android:1.0'
     compile 'com.trello:rxlifecycle-components:1.0'
 
-    compile 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'
+    compile rootProject.ext.textDrawable
 
     compile 'frankiesardo:icepick:3.2.0'
     provided 'frankiesardo:icepick-processor:3.2.0'

--- a/app/src/main/java/chat/rocket/android/activity/MainActivity.java
+++ b/app/src/main/java/chat/rocket/android/activity/MainActivity.java
@@ -8,6 +8,7 @@ import android.support.v7.graphics.drawable.DrawerArrowDrawable;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
 
+import java.util.List;
 import chat.rocket.android.LaunchUtil;
 import chat.rocket.android.R;
 import chat.rocket.android.api.MethodCallHelper;
@@ -233,14 +234,20 @@ public class MainActivity extends AbstractAuthedActivity {
                 .equalTo(RoomSubscription.ALERT, true)
                 .equalTo(RoomSubscription.OPEN, true)
                 .findAll())
-        .setOnUpdateListener(results -> updateRoomToolbarUnreadCount(results.size()));
+        .setOnUpdateListener(this::updateRoomToolbarUnreadCount);
     unreadRoomSubscriptionObserver.sub();
   }
 
-  private void updateRoomToolbarUnreadCount(int unreadCount) {
+  private void updateRoomToolbarUnreadCount(List<RoomSubscription> unreadRooms) {
     RoomToolbar toolbar = (RoomToolbar) findViewById(R.id.activity_main_toolbar);
     if (toolbar != null) {
-      toolbar.setUnreadBudge(unreadCount);
+      //ref: Rocket.Chat:client/startup/unread.js
+      final int numUnreadChannels = unreadRooms.size();
+      int numMentionsSum = 0;
+      for (RoomSubscription room : unreadRooms) {
+        numMentionsSum += room.getUnread();
+      }
+      toolbar.setUnreadBudge(numUnreadChannels, numMentionsSum);
     }
   }
 

--- a/app/src/main/java/chat/rocket/android/activity/MainActivity.java
+++ b/app/src/main/java/chat/rocket/android/activity/MainActivity.java
@@ -17,11 +17,14 @@ import chat.rocket.android.fragment.sidebar.SidebarMainFragment;
 import chat.rocket.android.helper.LogcatIfError;
 import chat.rocket.android.helper.TextUtils;
 import chat.rocket.android.model.ServerConfig;
+import chat.rocket.android.model.ddp.RoomSubscription;
 import chat.rocket.android.model.ddp.User;
 import chat.rocket.android.model.internal.Session;
 import chat.rocket.android.realm_helper.RealmHelper;
+import chat.rocket.android.realm_helper.RealmListObserver;
 import chat.rocket.android.realm_helper.RealmObjectObserver;
 import chat.rocket.android.realm_helper.RealmStore;
+import chat.rocket.android.widget.RoomToolbar;
 import hugo.weaving.DebugLog;
 
 /**
@@ -30,6 +33,7 @@ import hugo.weaving.DebugLog;
 public class MainActivity extends AbstractAuthedActivity {
 
   private RealmObjectObserver<Session> sessionObserver;
+  private RealmListObserver<RoomSubscription> unreadRoomSubscriptionObserver;
   private boolean isForeground;
   private StatusTicker statusTicker;
 
@@ -150,6 +154,7 @@ public class MainActivity extends AbstractAuthedActivity {
   protected void onServerConfigIdUpdated() {
     super.onServerConfigIdUpdated();
     updateSessionObserver();
+    updateUnreadRoomSubscriptionObserver();
     updateSidebarMainFragment();
   }
 
@@ -207,6 +212,38 @@ public class MainActivity extends AbstractAuthedActivity {
     }
   }
 
+  private void updateUnreadRoomSubscriptionObserver() {
+    if (unreadRoomSubscriptionObserver != null) {
+      unreadRoomSubscriptionObserver.unsub();
+      unreadRoomSubscriptionObserver = null;
+    }
+
+    if (serverConfigId == null) {
+      return;
+    }
+
+    RealmHelper realmHelper = RealmStore.get(serverConfigId);
+    if (realmHelper == null) {
+      return;
+    }
+
+    unreadRoomSubscriptionObserver = realmHelper
+        .createListObserver(realm ->
+            realm.where(RoomSubscription.class)
+                .equalTo(RoomSubscription.ALERT, true)
+                .equalTo(RoomSubscription.OPEN, true)
+                .findAll())
+        .setOnUpdateListener(results -> updateRoomToolbarUnreadCount(results.size()));
+    unreadRoomSubscriptionObserver.sub();
+  }
+
+  private void updateRoomToolbarUnreadCount(int unreadCount) {
+    RoomToolbar toolbar = (RoomToolbar) findViewById(R.id.activity_main_toolbar);
+    if (toolbar != null) {
+      toolbar.setUnreadBudge(unreadCount);
+    }
+  }
+
   private void updateSidebarMainFragment() {
     getSupportFragmentManager().beginTransaction()
         .replace(R.id.sidebar_fragment_container, SidebarMainFragment.create(serverConfigId))
@@ -230,6 +267,10 @@ public class MainActivity extends AbstractAuthedActivity {
     if (sessionObserver != null) {
       sessionObserver.unsub();
       sessionObserver = null;
+    }
+    if (unreadRoomSubscriptionObserver != null) {
+      unreadRoomSubscriptionObserver.unsub();
+      unreadRoomSubscriptionObserver = null;
     }
     super.onDestroy();
   }

--- a/app/src/main/java/chat/rocket/android/fragment/chatroom/AbstractChatRoomFragment.java
+++ b/app/src/main/java/chat/rocket/android/fragment/chatroom/AbstractChatRoomFragment.java
@@ -46,6 +46,5 @@ abstract class AbstractChatRoomFragment extends AbstractFragment {
     }
 
     roomToolbar.setRoomIcon(drawableResId);
-    roomToolbar.setUnreadBudge((int) (System.currentTimeMillis() % 15)); //TODO: just example!
   }
 }

--- a/app/src/main/java/chat/rocket/android/fragment/chatroom/AbstractChatRoomFragment.java
+++ b/app/src/main/java/chat/rocket/android/fragment/chatroom/AbstractChatRoomFragment.java
@@ -46,5 +46,6 @@ abstract class AbstractChatRoomFragment extends AbstractFragment {
     }
 
     roomToolbar.setRoomIcon(drawableResId);
+    roomToolbar.setUnreadBudge((int) (System.currentTimeMillis() % 15)); //TODO: just example!
   }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -18,6 +18,7 @@ ext {
   okhttp3 = 'com.squareup.okhttp3:okhttp:3.4.1'
   picasso = 'com.squareup.picasso:picasso:2.5.2'
   picasso2Okhttp3Downloader = 'com.jakewharton.picasso:picasso2-okhttp3-downloader:1.1.0'
+  textDrawable = 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'
 
   preDexLibs = !"true".equals(System.getenv("CI"))
 }

--- a/rocket-chat-android-widgets/build.gradle
+++ b/rocket-chat-android-widgets/build.gradle
@@ -35,6 +35,7 @@ dependencies {
   compile rootProject.ext.supportAppCompat
   compile rootProject.ext.supportDesign
   compile 'org.nibor.autolink:autolink:0.5.0'
+  compile 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'
   compile rootProject.ext.okhttp3
   compile rootProject.ext.picasso
   compile rootProject.ext.picasso2Okhttp3Downloader

--- a/rocket-chat-android-widgets/build.gradle
+++ b/rocket-chat-android-widgets/build.gradle
@@ -35,7 +35,7 @@ dependencies {
   compile rootProject.ext.supportAppCompat
   compile rootProject.ext.supportDesign
   compile 'org.nibor.autolink:autolink:0.5.0'
-  compile 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'
+  compile rootProject.ext.textDrawable
   compile rootProject.ext.okhttp3
   compile rootProject.ext.picasso
   compile rootProject.ext.picasso2Okhttp3Downloader

--- a/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/RoomToolbar.java
+++ b/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/RoomToolbar.java
@@ -2,13 +2,13 @@ package chat.rocket.android.widget;
 
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.graphics.drawable.VectorDrawableCompat;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.widget.TextViewCompat;
 import android.support.v7.widget.AppCompatImageView;
 import android.support.v7.widget.Toolbar;
@@ -24,7 +24,7 @@ import java.lang.reflect.Field;
 public class RoomToolbar extends Toolbar {
 
   private TextView titleTextView;
-  private ImageView budgeImageView;
+  private ImageView badgeImageView;
 
   public RoomToolbar(Context context) {
     super(context);
@@ -110,30 +110,35 @@ public class RoomToolbar extends Toolbar {
       return;
     }
 
-    if (budgeImageView == null) {
-      budgeImageView = new AppCompatImageView(getContext());
+    if (badgeImageView == null) {
+      badgeImageView = new AppCompatImageView(getContext());
+      badgeImageView.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
     }
 
-    if (budgeImageView.getParent() != this) { //ref: Toolbar#isChildOrHidden
-      addView(budgeImageView, generateDefaultLayoutParams());
+    if (badgeImageView.getParent() != this) { //ref: Toolbar#isChildOrHidden
+      addView(badgeImageView, generateDefaultLayoutParams());
     }
 
     if (numUnreadChannels > 0) {
-      budgeImageView.setImageDrawable(getBudgeDrawable(numMentionsSum));
-      budgeImageView.setVisibility(View.VISIBLE);
+      if (numMentionsSum > 0) {
+        badgeImageView.setImageDrawable(getBadgeDrawable(numMentionsSum));
+      } else {
+        badgeImageView.setScaleType(ImageView.ScaleType.CENTER);
+        badgeImageView.setImageResource(R.drawable.badge_without_number);
+      }
+      badgeImageView.setVisibility(View.VISIBLE);
     } else {
-      budgeImageView.setVisibility(View.GONE);
+      badgeImageView.setVisibility(View.GONE);
     }
   }
 
-  private Drawable getBudgeDrawable(int number) {
-    String icon = number > 99 ? "99+" :
-        (number <= 0 ? "" : Integer.toString(number));
+  private Drawable getBadgeDrawable(int number) {
+    String icon = number > 99 ? "99+" : Integer.toString(number);
     return TextDrawable.builder()
         .beginConfig()
         .useFont(Typeface.SANS_SERIF)
         .endConfig()
-        .buildRound(icon, Color.RED);
+        .buildRound(icon, ContextCompat.getColor(getContext(), R.color.badge_color));
   }
 
 
@@ -142,7 +147,7 @@ public class RoomToolbar extends Toolbar {
   protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
     super.onLayout(changed, left, top, right, bottom);
 
-    if (budgeImageView != null && budgeImageView.getVisibility() != View.GONE) {
+    if (badgeImageView != null && badgeImageView.getVisibility() != View.GONE) {
       try {
         Field field = Toolbar.class.getDeclaredField("mNavButtonView");
         field.setAccessible(true);
@@ -156,7 +161,7 @@ public class RoomToolbar extends Toolbar {
         int budgeRight = iconLeft + (iconRight - iconLeft) * 7 / 8;
         int budgeTop = iconTop + (iconBottom - iconTop) / 8;
         int budgeBottom = iconTop + (iconBottom - iconTop) * 3 / 8;
-        budgeImageView.layout(budgeLeft, budgeTop, budgeRight, budgeBottom);
+        badgeImageView.layout(budgeLeft, budgeTop, budgeRight, budgeBottom);
       } catch (Exception exception) {
         return;
       }

--- a/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/RoomToolbar.java
+++ b/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/RoomToolbar.java
@@ -157,11 +157,13 @@ public class RoomToolbar extends Toolbar {
         int iconRight = navButtonView.getRight();
         int iconBottom = navButtonView.getBottom();
 
-        int budgeLeft = iconLeft + (iconRight - iconLeft) * 5 / 8;
-        int budgeRight = iconLeft + (iconRight - iconLeft) * 7 / 8;
-        int budgeTop = iconTop + (iconBottom - iconTop) / 8;
-        int budgeBottom = iconTop + (iconBottom - iconTop) * 3 / 8;
-        badgeImageView.layout(budgeLeft, budgeTop, budgeRight, budgeBottom);
+        // put badge image at right-top side on the NavButtonView,
+        // with 1/8 margin and 1/4 scale.
+        int badgeLeft = iconLeft + (iconRight - iconLeft) * 5 / 8;
+        int badgeRight = iconLeft + (iconRight - iconLeft) * 7 / 8;
+        int badgeTop = iconTop + (iconBottom - iconTop) / 8;
+        int badgeBottom = iconTop + (iconBottom - iconTop) * 3 / 8;
+        badgeImageView.layout(badgeLeft, badgeTop, badgeRight, badgeBottom);
       } catch (Exception exception) {
         return;
       }

--- a/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/RoomToolbar.java
+++ b/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/RoomToolbar.java
@@ -105,7 +105,7 @@ public class RoomToolbar extends Toolbar {
     titleTextView.setCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null);
   }
 
-  public void setUnreadBudge(int numUnread) {
+  public void setUnreadBudge(int numUnreadChannels, int numMentionsSum) {
     if (getNavigationIcon() == null) {
       return;
     }
@@ -118,16 +118,17 @@ public class RoomToolbar extends Toolbar {
       addView(budgeImageView, generateDefaultLayoutParams());
     }
 
-    if (numUnread > 0) {
-      budgeImageView.setImageDrawable(getBudgeDrawable(numUnread));
+    if (numUnreadChannels > 0) {
+      budgeImageView.setImageDrawable(getBudgeDrawable(numMentionsSum));
       budgeImageView.setVisibility(View.VISIBLE);
     } else {
       budgeImageView.setVisibility(View.GONE);
     }
   }
 
-  private Drawable getBudgeDrawable(int numUnread) {
-    String icon = numUnread < 10 ? Integer.toString(numUnread) : "";
+  private Drawable getBudgeDrawable(int number) {
+    String icon = number > 99 ? "99+" :
+        (number <= 0 ? "" : Integer.toString(number));
     return TextDrawable.builder()
         .beginConfig()
         .useFont(Typeface.SANS_SERIF)

--- a/rocket-chat-android-widgets/src/main/res/drawable/badge_without_number.xml
+++ b/rocket-chat-android-widgets/src/main/res/drawable/badge_without_number.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+        android:shape="oval">
+    <solid android:color="@color/badge_color" />
+    <size android:width="@dimen/badge_size" android:height="@dimen/badge_size"/>
+</shape>

--- a/rocket-chat-android-widgets/src/main/res/values/badge_styles.xml
+++ b/rocket-chat-android-widgets/src/main/res/values/badge_styles.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="badge_color">#FFFF0000</color>
+    <dimen name="badge_size">8dp</dimen>
+</resources>


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #134 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
add indicator into the burger icon for notifying the count of unread room subscriptions.

<img width="380" src="https://cloud.githubusercontent.com/assets/11763113/21982807/76776d36-dc31-11e6-93cd-61f167c7ebc2.png">

Rocket.Chat (webapp) originally shows "999+" badge when the number of mentions > 999. However "999+" cannot be layout on a small badge. So "99+" is used instead in this app.

<img width=380 src="https://cloud.githubusercontent.com/assets/11763113/21969117/ceaa8d4c-dbde-11e6-9599-37f4fd910619.png">
