### PR TITLE
auto scroll to latest message

### DIFF
--- a/app/src/main/java/chat/rocket/android/fragment/chatroom/RoomFragment.java
+++ b/app/src/main/java/chat/rocket/android/fragment/chatroom/RoomFragment.java
@@ -33,7 +33,7 @@ import chat.rocket.android.helper.RecyclerViewScrolledToBottomListener;
 import chat.rocket.android.helper.TextUtils;
 import chat.rocket.android.layouthelper.chatroom.MessageFormManager;
 import chat.rocket.android.layouthelper.chatroom.MessageListAdapter;
-import chat.rocket.android.layouthelper.chatroom.NewMessageIndicatorManager;
+import chat.rocket.android.layouthelper.chatroom.AbstractNewMessageIndicatorManager;
 import chat.rocket.android.layouthelper.chatroom.PairedMessage;
 import chat.rocket.android.layouthelper.extra_action.MessageExtraActionBehavior;
 import chat.rocket.android.layouthelper.extra_action.upload.AbstractUploadActionItem;
@@ -75,7 +75,7 @@ public class RoomFragment extends AbstractChatRoomFragment
   private RealmObjectObserver<LoadMessageProcedure> procedureObserver;
   private MessageFormManager messageFormManager;
   private RecyclerViewAutoScrollManager autoScrollManager;
-  private NewMessageIndicatorManager newMessageIndicatorManager;
+  private AbstractNewMessageIndicatorManager newMessageIndicatorManager;
   private Snackbar unreadIndicator;
   private boolean previousUnreadMessageExists;
 
@@ -173,7 +173,7 @@ public class RoomFragment extends AbstractChatRoomFragment
     listView.addOnScrollListener(
         new RecyclerViewScrolledToBottomListener(layoutManager, 1, this::markAsReadIfNeeded));
 
-    newMessageIndicatorManager = new NewMessageIndicatorManager() {
+    newMessageIndicatorManager = new AbstractNewMessageIndicatorManager() {
       @Override
       protected void onShowIndicator(int count, boolean onlyAlreadyShown) {
         if ((onlyAlreadyShown && unreadIndicator != null && unreadIndicator.isShown())

--- a/app/src/main/java/chat/rocket/android/fragment/chatroom/RoomFragment.java
+++ b/app/src/main/java/chat/rocket/android/fragment/chatroom/RoomFragment.java
@@ -28,6 +28,7 @@ import chat.rocket.android.helper.LoadMoreScrollListener;
 import chat.rocket.android.helper.LogcatIfError;
 import chat.rocket.android.helper.OnBackPressListener;
 import chat.rocket.android.helper.RecyclerViewAutoScrollManager;
+import chat.rocket.android.helper.RecyclerViewScrolledToBottomListener;
 import chat.rocket.android.helper.TextUtils;
 import chat.rocket.android.layouthelper.chatroom.MessageFormManager;
 import chat.rocket.android.layouthelper.chatroom.MessageListAdapter;
@@ -157,6 +158,8 @@ public class RoomFragment extends AbstractChatRoomFragment
       }
     };
     listView.addOnScrollListener(scrollListener);
+    listView.addOnScrollListener(
+        new RecyclerViewScrolledToBottomListener(layoutManager, 1, this::markAsReadIfNeeded));
 
     setupSideMenu();
     setupMessageComposer();

--- a/app/src/main/java/chat/rocket/android/fragment/chatroom/RoomFragment.java
+++ b/app/src/main/java/chat/rocket/android/fragment/chatroom/RoomFragment.java
@@ -28,6 +28,7 @@ import chat.rocket.android.helper.LoadMoreScrollListener;
 import chat.rocket.android.helper.LogcatIfError;
 import chat.rocket.android.helper.OnBackPressListener;
 import chat.rocket.android.helper.TextUtils;
+import chat.rocket.android.layouthelper.ExtRealmModelListAdapter;
 import chat.rocket.android.layouthelper.chatroom.MessageFormManager;
 import chat.rocket.android.layouthelper.chatroom.MessageListAdapter;
 import chat.rocket.android.layouthelper.chatroom.PairedMessage;
@@ -70,6 +71,17 @@ public class RoomFragment extends AbstractChatRoomFragment
   private LoadMoreScrollListener scrollListener;
   private RealmObjectObserver<LoadMessageProcedure> procedureObserver;
   private MessageFormManager messageFormManager;
+  private LinearLayoutManager layoutManager;
+  private boolean userScrolledToEnd = true;
+
+  private ExtRealmModelListAdapter.UpdateListener updateListener =
+      count -> {
+        if (userScrolledToEnd) {
+          scrollToEnd();
+        } else {
+          // showNewMessagesAtEndIndicator();
+        }
+      };
 
   public RoomFragment() {
   }
@@ -142,9 +154,10 @@ public class RoomFragment extends AbstractChatRoomFragment
     listView.setAdapter(adapter);
     adapter.setOnItemClickListener(this);
 
-    LinearLayoutManager layoutManager = new LinearLayoutManager(getContext(),
+    layoutManager = new LinearLayoutManager(getContext(),
         LinearLayoutManager.VERTICAL, true);
     listView.setLayoutManager(layoutManager);
+    adapter.setUpdateListener(updateListener);
 
     scrollListener = new LoadMoreScrollListener(layoutManager, 40) {
       @Override
@@ -153,6 +166,13 @@ public class RoomFragment extends AbstractChatRoomFragment
       }
     };
     listView.addOnScrollListener(scrollListener);
+    listView.addOnScrollListener(new RecyclerView.OnScrollListener() {
+      @Override
+      public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
+        super.onScrollStateChanged(recyclerView, newState);
+        setUserScrolledToEnd(newState);
+      }
+    });
 
     setupSideMenu();
     setupMessageComposer();
@@ -371,5 +391,19 @@ public class RoomFragment extends AbstractChatRoomFragment
   @NeedsPermission(Manifest.permission.READ_EXTERNAL_STORAGE)
   protected void onExtraActionSelected(MessageExtraActionBehavior action) {
     action.handleItemSelectedOnFragment(RoomFragment.this);
+  }
+
+  private void setUserScrolledToEnd(int newState) {
+    if (newState == RecyclerView.SCROLL_STATE_DRAGGING
+        || newState == RecyclerView.SCROLL_STATE_IDLE) {
+      userScrolledToEnd = layoutManager.findFirstCompletelyVisibleItemPosition() == 1;
+    }
+  }
+
+  private void scrollToEnd() {
+    if (layoutManager == null) {
+      return;
+    }
+    layoutManager.scrollToPosition(0);
   }
 }

--- a/app/src/main/java/chat/rocket/android/fragment/chatroom/RoomFragment.java
+++ b/app/src/main/java/chat/rocket/android/fragment/chatroom/RoomFragment.java
@@ -305,6 +305,8 @@ public class RoomFragment extends AbstractChatRoomFragment
                 .put(Message.SYNC_STATE, SyncState.NOT_SYNCED)
                 .put(Message.TIMESTAMP, System.currentTimeMillis())
                 .put(Message.ROOM_ID, roomId)
+                .put(Message.USER, new JSONObject()
+                    .put(User.ID, userId))
                 .put(Message.MESSAGE, messageText)))
             .onSuccess(_task -> {
               scrollToLatestMessage();

--- a/app/src/main/java/chat/rocket/android/fragment/chatroom/RoomFragment.java
+++ b/app/src/main/java/chat/rocket/android/fragment/chatroom/RoomFragment.java
@@ -198,7 +198,7 @@ public class RoomFragment extends AbstractChatRoomFragment
   private void scrollToLatestMessage() {
     RecyclerView listView = (RecyclerView) rootView.findViewById(R.id.recyclerview);
     if (listView != null) {
-      listView.smoothScrollToPosition(0);
+      listView.scrollToPosition(0);
     }
   }
 

--- a/app/src/main/java/chat/rocket/android/helper/RecyclerViewAutoScrollManager.java
+++ b/app/src/main/java/chat/rocket/android/helper/RecyclerViewAutoScrollManager.java
@@ -1,0 +1,25 @@
+package chat.rocket.android.helper;
+
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+
+/**
+ * workaround for bug https://code.google.com/p/android/issues/detail?id=174227
+ */
+public class RecyclerViewAutoScrollManager extends RecyclerView.AdapterDataObserver {
+
+  private final LinearLayoutManager linearLayoutManager;
+
+  public RecyclerViewAutoScrollManager(LinearLayoutManager linearLayoutManager) {
+    this.linearLayoutManager = linearLayoutManager;
+  }
+
+  @Override
+  public void onItemRangeInserted(int positionStart, int itemCount) {
+    super.onItemRangeInserted(positionStart, itemCount);
+
+    if (linearLayoutManager.findFirstVisibleItemPosition() <= positionStart) {
+      linearLayoutManager.scrollToPosition(positionStart);
+    }
+  }
+}

--- a/app/src/main/java/chat/rocket/android/helper/RecyclerViewAutoScrollManager.java
+++ b/app/src/main/java/chat/rocket/android/helper/RecyclerViewAutoScrollManager.java
@@ -20,6 +20,12 @@ public class RecyclerViewAutoScrollManager extends RecyclerView.AdapterDataObser
 
     if (linearLayoutManager.findFirstVisibleItemPosition() <= positionStart) {
       linearLayoutManager.scrollToPosition(positionStart);
+    } else {
+      onAutoScrollMissed();
     }
+  }
+
+  protected void onAutoScrollMissed() {
+    //do nothing by default.
   }
 }

--- a/app/src/main/java/chat/rocket/android/helper/RecyclerViewScrolledToBottomListener.java
+++ b/app/src/main/java/chat/rocket/android/helper/RecyclerViewScrolledToBottomListener.java
@@ -1,0 +1,67 @@
+package chat.rocket.android.helper;
+
+import android.os.Handler;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+
+/**
+ * ScrollListener for detecting scrolled on the bottom of the RecyclerView.
+ */
+public class RecyclerViewScrolledToBottomListener extends RecyclerView.OnScrollListener {
+
+  /**
+   * callback.
+   */
+  public interface Callback {
+    void onScrolledToBottom();
+  }
+
+  private final LinearLayoutManager layoutManager;
+  private final int thresholdPosition;
+  private final Handler handler;
+  private final Callback callback;
+
+  /**
+   * Trigger callback if the bottom item position > thresholdPosition.
+   */
+  public RecyclerViewScrolledToBottomListener(LinearLayoutManager layoutManager,
+                                              int thresholdPosition, Callback callback) {
+    this.layoutManager = layoutManager;
+    this.thresholdPosition = thresholdPosition;
+    this.callback = callback;
+
+    this.handler = new Handler() {
+      @Override
+      public void handleMessage(android.os.Message msg) {
+        onScrollEnd();
+      }
+    };
+  }
+
+
+  @Override
+  public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
+    super.onScrolled(recyclerView, dx, dy);
+    handler.removeMessages(0);
+    handler.sendEmptyMessageDelayed(0, 120);
+  }
+
+  private void onScrollEnd() {
+    if (layoutManager.getReverseLayout()) {
+      if (layoutManager.findFirstVisibleItemPosition() <= thresholdPosition) {
+        doCallback();
+      }
+    } else {
+      if (layoutManager.findLastVisibleItemPosition() >= thresholdPosition) {
+        doCallback();
+      }
+    }
+  }
+
+  private void doCallback() {
+    if (callback != null) {
+      callback.onScrolledToBottom();
+    }
+  }
+}
+

--- a/app/src/main/java/chat/rocket/android/helper/RecyclerViewScrolledToBottomListener.java
+++ b/app/src/main/java/chat/rocket/android/helper/RecyclerViewScrolledToBottomListener.java
@@ -40,8 +40,8 @@ public class RecyclerViewScrolledToBottomListener extends RecyclerView.OnScrollL
 
 
   @Override
-  public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
-    super.onScrolled(recyclerView, dx, dy);
+  public void onScrolled(RecyclerView recyclerView, int deltaX, int deltaY) {
+    super.onScrolled(recyclerView, deltaX, deltaY);
     handler.removeMessages(0);
     handler.sendEmptyMessageDelayed(0, 120);
   }

--- a/app/src/main/java/chat/rocket/android/layouthelper/ExtRealmModelListAdapter.java
+++ b/app/src/main/java/chat/rocket/android/layouthelper/ExtRealmModelListAdapter.java
@@ -44,7 +44,7 @@ public abstract class ExtRealmModelListAdapter<T extends RealmObject, VM,
     this.updateListener = updateListener;
   }
 
-  protected ListUpdateCallback listUpdateCallback = new ListUpdateCallback() {
+  private final ListUpdateCallback listUpdateCallback = new ListUpdateCallback() {
     @Override
     public void onInserted(int position, int count) {
       notifyItemRangeInserted(position + 1, count);
@@ -117,7 +117,7 @@ public abstract class ExtRealmModelListAdapter<T extends RealmObject, VM,
   }
 
   @Override
-  public ListUpdateCallback getListUpdateCallback() {
+  protected ListUpdateCallback getListUpdateCallback() {
     return listUpdateCallback;
   }
 

--- a/app/src/main/java/chat/rocket/android/layouthelper/ExtRealmModelListAdapter.java
+++ b/app/src/main/java/chat/rocket/android/layouthelper/ExtRealmModelListAdapter.java
@@ -17,8 +17,6 @@ public abstract class ExtRealmModelListAdapter<T extends RealmObject, VM,
   protected static final int VIEW_TYPE_HEADER = -1;
   protected static final int VIEW_TYPE_FOOTER = -2;
 
-  private UpdateListener updateListener;
-
   protected ExtRealmModelListAdapter(Context context) {
     super(context);
   }
@@ -40,17 +38,10 @@ public abstract class ExtRealmModelListAdapter<T extends RealmObject, VM,
     notifyItemChanged(position + 1);
   }
 
-  public void setUpdateListener(UpdateListener updateListener) {
-    this.updateListener = updateListener;
-  }
-
   private final ListUpdateCallback listUpdateCallback = new ListUpdateCallback() {
     @Override
     public void onInserted(int position, int count) {
       notifyItemRangeInserted(position + 1, count);
-      if (updateListener != null) {
-        updateListener.onInserted(count);
-      }
     }
 
     @Override
@@ -119,11 +110,5 @@ public abstract class ExtRealmModelListAdapter<T extends RealmObject, VM,
   @Override
   protected ListUpdateCallback getListUpdateCallback() {
     return listUpdateCallback;
-  }
-
-  // We'll be using the insert event only as of now
-  // Let's add more events when/if needed
-  public interface UpdateListener {
-    void onInserted(int count);
   }
 }

--- a/app/src/main/java/chat/rocket/android/layouthelper/ExtRealmModelListAdapter.java
+++ b/app/src/main/java/chat/rocket/android/layouthelper/ExtRealmModelListAdapter.java
@@ -17,6 +17,8 @@ public abstract class ExtRealmModelListAdapter<T extends RealmObject, VM,
   protected static final int VIEW_TYPE_HEADER = -1;
   protected static final int VIEW_TYPE_FOOTER = -2;
 
+  private UpdateListener updateListener;
+
   protected ExtRealmModelListAdapter(Context context) {
     super(context);
   }
@@ -38,10 +40,17 @@ public abstract class ExtRealmModelListAdapter<T extends RealmObject, VM,
     notifyItemChanged(position + 1);
   }
 
+  public void setUpdateListener(UpdateListener updateListener) {
+    this.updateListener = updateListener;
+  }
+
   protected ListUpdateCallback listUpdateCallback = new ListUpdateCallback() {
     @Override
     public void onInserted(int position, int count) {
       notifyItemRangeInserted(position + 1, count);
+      if (updateListener != null) {
+        updateListener.onInserted(count);
+      }
     }
 
     @Override
@@ -110,5 +119,11 @@ public abstract class ExtRealmModelListAdapter<T extends RealmObject, VM,
   @Override
   public ListUpdateCallback getListUpdateCallback() {
     return listUpdateCallback;
+  }
+
+  // We'll be using the insert event only as of now
+  // Let's add more events when/if needed
+  public interface UpdateListener {
+    void onInserted(int count);
   }
 }

--- a/app/src/main/java/chat/rocket/android/layouthelper/chatroom/AbstractNewMessageIndicatorManager.java
+++ b/app/src/main/java/chat/rocket/android/layouthelper/chatroom/AbstractNewMessageIndicatorManager.java
@@ -3,7 +3,7 @@ package chat.rocket.android.layouthelper.chatroom;
 /**
  * manager class for showing "You have XX messages" indicator.
  */
-public abstract class NewMessageIndicatorManager {
+public abstract class AbstractNewMessageIndicatorManager {
   private int count;
   private boolean onlyAlreadyShown;
 

--- a/app/src/main/java/chat/rocket/android/layouthelper/chatroom/NewMessageIndicatorManager.java
+++ b/app/src/main/java/chat/rocket/android/layouthelper/chatroom/NewMessageIndicatorManager.java
@@ -1,0 +1,43 @@
+package chat.rocket.android.layouthelper.chatroom;
+
+/**
+ * manager class for showing "You have XX messages" indicator.
+ */
+public abstract class NewMessageIndicatorManager {
+  private int count;
+  private boolean onlyAlreadyShown;
+
+  /**
+   * update the number of unread message.
+   */
+  public void updateNewMessageCount(int count) {
+    if (count > 0) {
+      this.count = count;
+      update();
+      onlyAlreadyShown = true;
+    } else {
+      reset();
+    }
+  }
+
+  /**
+   * Should call this method when user checked new message.
+   */
+  public void reset() {
+    count = 0;
+    onlyAlreadyShown = false;
+    update();
+  }
+
+  private void update() {
+    if (count > 0) {
+      onShowIndicator(count, onlyAlreadyShown);
+    } else {
+      onHideIndicator();
+    }
+  }
+
+  protected abstract void onShowIndicator(int count, boolean onlyAlreadyShown);
+
+  protected abstract void onHideIndicator();
+}

--- a/app/src/main/java/chat/rocket/android/model/ddp/Message.java
+++ b/app/src/main/java/chat/rocket/android/model/ddp/Message.java
@@ -25,6 +25,7 @@ public class Message extends RealmObject {
   @SuppressWarnings({"PMD.AvoidFieldNameMatchingTypeName"})
   public static final String MESSAGE = "msg";
   public static final String USER = "u";
+  public static final String USER_ID = "u._id";
   public static final String GROUPABLE = "groupable";
   public static final String ATTACHMENTS = "attachments";
   public static final String URLS = "urls";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,9 @@
     <string name="resend">Resend</string>
     <string name="discard">Discard</string>
 
+    <string name="fmt_dialog_view_latest_message_title">New %d messages</string>
+    <string name="dialog_view_latest_message_action">View</string>
+
     <string name="file_uploading_title">Uploading…</string>
 
     <string name="dialog_user_registration_email">Email</string>

--- a/realm-helpers/src/main/java/chat/rocket/android/realm_helper/RealmModelListAdapter.java
+++ b/realm-helpers/src/main/java/chat/rocket/android/realm_helper/RealmModelListAdapter.java
@@ -103,7 +103,31 @@ public abstract class RealmModelListAdapter<T extends RealmObject, VM,
 
   protected abstract DiffUtil.Callback getDiffCallback(List<VM> oldData, List<VM> newData);
 
-  protected abstract ListUpdateCallback getListUpdateCallback();
+  private final ListUpdateCallback listUpdateCallback = new ListUpdateCallback() {
+    @Override
+    public void onInserted(int position, int count) {
+      notifyItemRangeInserted(position, count);
+    }
+
+    @Override
+    public void onRemoved(int position, int count) {
+      notifyItemRangeRemoved(position, count);
+    }
+
+    @Override
+    public void onMoved(int fromPosition, int toPosition) {
+      notifyItemMoved(fromPosition, toPosition);
+    }
+
+    @Override
+    public void onChanged(int position, int count, Object payload) {
+      notifyItemRangeChanged(position, count, payload);
+    }
+  };
+
+  protected ListUpdateCallback getListUpdateCallback() {
+    return listUpdateCallback;
+  }
 
   public void setOnItemClickListener(OnItemClickListener<VM> onItemClickListener) {
     this.onItemClickListener = onItemClickListener;


### PR DESCRIPTION
originally proposed in #146 (Thanks to laggedHero! 🙇 )

---

After DiffUtils is intriduced in #146, message list view is not automatically scrolled when new message is arrived. (ref: https://code.google.com/p/android/issues/detail?id=174227 )


* Automatically scroll to the new message  if the scroll position is near the new message
* show indicator if user is reading very past message not to disturb reading