### PR TITLE
use OkHttp 3.5.0

### DIFF
--- a/android-ddp/build.gradle
+++ b/android-ddp/build.gradle
@@ -37,7 +37,7 @@ android {
 dependencies {
   compile project(':log-wrapper')
   compile rootProject.ext.supportAnnotations
-  compile 'com.squareup.okhttp3:okhttp-ws:3.4.1'
+  compile rootProject.ext.okhttp3
   compile rootProject.ext.rxJava
   compile rootProject.ext.boltsTask
 }

--- a/android-ddp/src/main/java/chat/rocket/android_ddp/rx/RxWebSocket.java
+++ b/android-ddp/src/main/java/chat/rocket/android_ddp/rx/RxWebSocket.java
@@ -4,13 +4,9 @@ import java.io.IOException;
 import chat.rocket.android.log.RCLog;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import okhttp3.RequestBody;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
-import okhttp3.ws.WebSocket;
-import okhttp3.ws.WebSocketCall;
-import okhttp3.ws.WebSocketListener;
-import okio.Buffer;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
 import rx.Observable;
 import rx.Subscriber;
 import rx.exceptions.OnErrorNotImplementedException;
@@ -28,12 +24,11 @@ public class RxWebSocket {
 
   public ConnectableObservable<RxWebSocketCallback.Base> connect(String url) {
     final Request request = new Request.Builder().url(url).build();
-    WebSocketCall call = WebSocketCall.create(httpClient, request);
 
     return Observable.create(new Observable.OnSubscribe<RxWebSocketCallback.Base>() {
       @Override
       public void call(Subscriber<? super RxWebSocketCallback.Base> subscriber) {
-        call.enqueue(new WebSocketListener() {
+        httpClient.newWebSocket(request, new WebSocketListener() {
           @Override
           public void onOpen(WebSocket webSocket, Response response) {
             isConnected = true;
@@ -42,29 +37,23 @@ public class RxWebSocket {
           }
 
           @Override
-          public void onFailure(IOException e, Response response) {
+          public void onFailure(WebSocket webSocket, Throwable err, Response response) {
             try {
               isConnected = false;
-              subscriber.onError(new RxWebSocketCallback.Failure(webSocket, e, response));
+              subscriber.onError(new RxWebSocketCallback.Failure(webSocket, err, response));
             } catch (OnErrorNotImplementedException ex) {
               RCLog.w(ex, "OnErrorNotImplementedException ignored");
             }
           }
 
           @Override
-          public void onMessage(ResponseBody responseBody) throws IOException {
+          public void onMessage(WebSocket webSocket, String text) {
             isConnected = true;
-            subscriber.onNext(new RxWebSocketCallback.Message(webSocket, responseBody));
+            subscriber.onNext(new RxWebSocketCallback.Message(webSocket, text));
           }
 
           @Override
-          public void onPong(Buffer payload) {
-            isConnected = true;
-            subscriber.onNext(new RxWebSocketCallback.Pong(webSocket, payload));
-          }
-
-          @Override
-          public void onClose(int code, String reason) {
+          public void onClosed(WebSocket webSocket, int code, String reason) {
             isConnected = false;
             subscriber.onNext(new RxWebSocketCallback.Close(webSocket, code, reason));
             subscriber.onCompleted();
@@ -75,7 +64,7 @@ public class RxWebSocket {
   }
 
   public void sendText(String message) throws IOException {
-    webSocket.sendMessage(RequestBody.create(WebSocket.TEXT, message));
+    webSocket.send(message);
   }
 
   public boolean isConnected() {

--- a/android-ddp/src/main/java/chat/rocket/android_ddp/rx/RxWebSocketCallback.java
+++ b/android-ddp/src/main/java/chat/rocket/android_ddp/rx/RxWebSocketCallback.java
@@ -2,12 +2,9 @@ package chat.rocket.android_ddp.rx;
 
 import static android.R.attr.type;
 
-import java.io.IOException;
 import chat.rocket.android.log.RCLog;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
-import okhttp3.ws.WebSocket;
-import okio.Buffer;
+import okhttp3.WebSocket;
 
 public class RxWebSocketCallback {
   public static abstract class Base {
@@ -38,8 +35,8 @@ public class RxWebSocketCallback {
     public WebSocket ws;
     public Response response;
 
-    public Failure(WebSocket websocket, IOException e, Response response) {
-      super(e);
+    public Failure(WebSocket websocket, Throwable err, Response response) {
+      super(err);
       this.ws = websocket;
       this.response = response;
     }
@@ -57,10 +54,10 @@ public class RxWebSocketCallback {
   public static class Message extends Base {
     public String responseBodyString;
 
-    public Message(WebSocket websocket, ResponseBody responseBody) {
+    public Message(WebSocket websocket, String responseBody) {
       super("Message", websocket);
       try {
-        this.responseBodyString = responseBody.string();
+        this.responseBodyString = responseBody;
       } catch (Exception e) {
         RCLog.e(e, "error in reading response(Message)");
       }
@@ -69,15 +66,6 @@ public class RxWebSocketCallback {
     @Override
     public String toString() {
       return "[" + type + "] " + responseBodyString;
-    }
-  }
-
-  public static class Pong extends Base {
-    public Buffer payload;
-
-    public Pong(WebSocket websocket, Buffer payload) {
-      super("Pong", websocket);
-      this.payload = payload;
     }
   }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -15,7 +15,7 @@ ext {
 
   rxJava = 'io.reactivex:rxjava:1.2.2'
   boltsTask = 'com.parse.bolts:bolts-tasks:1.4.0'
-  okhttp3 = 'com.squareup.okhttp3:okhttp:3.4.1'
+  okhttp3 = 'com.squareup.okhttp3:okhttp:3.5.0'
   picasso = 'com.squareup.picasso:picasso:2.5.2'
   picasso2Okhttp3Downloader = 'com.jakewharton.picasso:picasso2-okhttp3-downloader:1.1.0'
   textDrawable = 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

`okhttp-ws` is removed in OkHttp 3.5.
https://medium.com/square-corner-blog/web-sockets-now-shipping-in-okhttp-3-5-463a9eec82d1#.o8y2u2h9c

`android-ddp` has dependency with it, so it is changed in this pull request.