### PR TITLE
Better handling of attachments

### DIFF
--- a/app/src/main/java/chat/rocket/android/helper/Avatar.java
+++ b/app/src/main/java/chat/rocket/android/helper/Avatar.java
@@ -30,16 +30,10 @@ public class Avatar {
   };
   private final String hostname;
   private final String username;
-  private final String avatarUrl;
 
   public Avatar(String hostname, String username) {
-    this(hostname, username, null);
-  }
-
-  public Avatar(String hostname, String username, String avatarUrl) {
     this.hostname = hostname;
     this.username = username;
-    this.avatarUrl = avatarUrl;
   }
 
   private static int getColorForUser(String username) {
@@ -82,15 +76,11 @@ public class Avatar {
   private String getImageUrl() {
     //from Rocket.Chat:packages/rocketchat-ui/lib/avatar.coffee
     //REMARK! this is often SVG image! (see: Rocket.Chat:server/startup/avatar.coffee)
-    if (TextUtils.isEmpty(avatarUrl)) {
-      try {
-        return "https://" + hostname + "/avatar/" + URLEncoder.encode(username, "UTF-8") + ".jpg";
-      } catch (UnsupportedEncodingException exception) {
-        RCLog.e(exception, "failed to get URL for user: %s", username);
-        return null;
-      }
-    } else {
-      return avatarUrl;
+    try {
+      return "https://" + hostname + "/avatar/" + URLEncoder.encode(username, "UTF-8") + ".jpg";
+    } catch (UnsupportedEncodingException exception) {
+      RCLog.e(exception, "failed to get URL for user: %s", username);
+      return null;
     }
   }
 
@@ -109,7 +99,7 @@ public class Avatar {
         .into(imageView);
   }
 
-  private Drawable getTextDrawable(Context context) {
+  public Drawable getTextDrawable(Context context) {
     if (username == null) {
       return null;
     }

--- a/app/src/main/java/chat/rocket/android/helper/Avatar.java
+++ b/app/src/main/java/chat/rocket/android/helper/Avatar.java
@@ -30,16 +30,16 @@ public class Avatar {
   };
   private final String hostname;
   private final String username;
-  private final String avatar;
+  private final String avatarUrl;
 
   public Avatar(String hostname, String username) {
     this(hostname, username, null);
   }
 
-  public Avatar(String hostname, String username, String avatar) {
+  public Avatar(String hostname, String username, String avatarUrl) {
     this.hostname = hostname;
     this.username = username;
-    this.avatar = avatar;
+    this.avatarUrl = avatarUrl;
   }
 
   private static int getColorForUser(String username) {
@@ -82,7 +82,7 @@ public class Avatar {
   private String getImageUrl() {
     //from Rocket.Chat:packages/rocketchat-ui/lib/avatar.coffee
     //REMARK! this is often SVG image! (see: Rocket.Chat:server/startup/avatar.coffee)
-    if (TextUtils.isEmpty(avatar)) {
+    if (TextUtils.isEmpty(avatarUrl)) {
       try {
         return "https://" + hostname + "/avatar/" + URLEncoder.encode(username, "UTF-8") + ".jpg";
       } catch (UnsupportedEncodingException exception) {
@@ -90,7 +90,7 @@ public class Avatar {
         return null;
       }
     } else {
-      return avatar;
+      return avatarUrl;
     }
   }
 

--- a/app/src/main/java/chat/rocket/android/model/ddp/Message.java
+++ b/app/src/main/java/chat/rocket/android/model/ddp/Message.java
@@ -38,6 +38,8 @@ public class Message extends RealmObject {
   private String msg;
   private User u;
   private boolean groupable;
+  private String alias;
+  private String avatar;
   private String attachments; //JSONArray.
   private String urls; //JSONArray.
 
@@ -133,6 +135,22 @@ public class Message extends RealmObject {
     this.urls = urls;
   }
 
+  public String getAlias() {
+    return alias;
+  }
+
+  public void setAlias(String alias) {
+    this.alias = alias;
+  }
+
+  public String getAvatar() {
+    return avatar;
+  }
+
+  public void setAvatar(String avatar) {
+    this.avatar = avatar;
+  }
+
   @Override
   public String toString() {
     return "Message{" +
@@ -144,6 +162,8 @@ public class Message extends RealmObject {
         ", msg='" + msg + '\'' +
         ", u=" + u +
         ", groupable=" + groupable +
+        ", alias='" + alias + '\'' +
+        ", avatar='" + avatar + '\'' +
         ", attachments='" + attachments + '\'' +
         ", urls='" + urls + '\'' +
         '}';
@@ -184,6 +204,12 @@ public class Message extends RealmObject {
     if (u != null ? !u.equals(message.u) : message.u != null) {
       return false;
     }
+    if (alias != null ? !alias.equals(message.alias) : message.alias != null) {
+      return false;
+    }
+    if (avatar != null ? !avatar.equals(message.avatar) : message.avatar != null) {
+      return false;
+    }
     if (attachments != null ? !attachments.equals(message.attachments)
         : message.attachments != null) {
       return false;
@@ -202,6 +228,8 @@ public class Message extends RealmObject {
     result = 31 * result + (msg != null ? msg.hashCode() : 0);
     result = 31 * result + (u != null ? u.hashCode() : 0);
     result = 31 * result + (groupable ? 1 : 0);
+    result = 31 * result + (alias != null ? alias.hashCode() : 0);
+    result = 31 * result + (avatar != null ? avatar.hashCode() : 0);
     result = 31 * result + (attachments != null ? attachments.hashCode() : 0);
     result = 31 * result + (urls != null ? urls.hashCode() : 0);
     return result;

--- a/app/src/main/java/chat/rocket/android/renderer/MessageRenderer.java
+++ b/app/src/main/java/chat/rocket/android/renderer/MessageRenderer.java
@@ -35,7 +35,7 @@ public class MessageRenderer extends AbstractRenderer<Message> {
         imageView.setImageResource(R.drawable.ic_error_outline_black_24dp);
         break;
       default:
-        userRenderer.avatarInto(imageView, hostname);
+        userRenderer.avatarInto(imageView, hostname, object.getAvatar());
         break;
     }
     return this;
@@ -45,7 +45,7 @@ public class MessageRenderer extends AbstractRenderer<Message> {
    * show Username in textView.
    */
   public MessageRenderer usernameInto(TextView textView) {
-    userRenderer.usernameInto(textView);
+    userRenderer.usernameInto(textView, object.getAlias());
     return this;
   }
 

--- a/app/src/main/java/chat/rocket/android/renderer/MessageRenderer.java
+++ b/app/src/main/java/chat/rocket/android/renderer/MessageRenderer.java
@@ -1,15 +1,23 @@
 package chat.rocket.android.renderer;
 
 import android.content.Context;
+import android.graphics.Color;
+import android.text.Spannable;
+import android.text.SpannableStringBuilder;
+import android.text.style.ForegroundColorSpan;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.squareup.picasso.Picasso;
+
 import chat.rocket.android.R;
+import chat.rocket.android.helper.Avatar;
 import chat.rocket.android.helper.DateTime;
 import chat.rocket.android.helper.TextUtils;
 import chat.rocket.android.model.SyncState;
 import chat.rocket.android.model.ddp.Message;
+import chat.rocket.android.model.ddp.User;
 import chat.rocket.android.widget.message.RocketChatMessageAttachmentsLayout;
 import chat.rocket.android.widget.message.RocketChatMessageLayout;
 import chat.rocket.android.widget.message.RocketChatMessageUrlsLayout;
@@ -30,13 +38,14 @@ public class MessageRenderer extends AbstractRenderer<Message> {
    * show Avatar image.
    */
   public MessageRenderer avatarInto(ImageView imageView, String hostname) {
-    switch (object.getSyncState()) {
-      case SyncState.FAILED:
-        imageView.setImageResource(R.drawable.ic_error_outline_black_24dp);
-        break;
-      default:
-        userRenderer.avatarInto(imageView, hostname, object.getAvatar());
-        break;
+    if (object.getSyncState() == SyncState.FAILED) {
+      imageView.setImageResource(R.drawable.ic_error_outline_black_24dp);
+    } else if (TextUtils.isEmpty(object.getAvatar())) {
+      userRenderer.avatarInto(imageView, hostname);
+    } else {
+      final User user = object.getUser();
+      setAvatarInto(object.getAvatar(), hostname, user == null ? null : user.getUsername(),
+          imageView);
     }
     return this;
   }
@@ -45,7 +54,12 @@ public class MessageRenderer extends AbstractRenderer<Message> {
    * show Username in textView.
    */
   public MessageRenderer usernameInto(TextView textView) {
-    userRenderer.usernameInto(textView, object.getAlias());
+    if (TextUtils.isEmpty(object.getAlias())) {
+      userRenderer.usernameInto(textView);
+    } else {
+      final User user = object.getUser();
+      setAliasInto(object.getAlias(), user == null ? null : user.getUsername(), textView);
+    }
     return this;
   }
 
@@ -122,6 +136,31 @@ public class MessageRenderer extends AbstractRenderer<Message> {
     }
 
     return this;
+  }
+
+  private void setAvatarInto(String avatar, String hostname, String username, ImageView imageView) {
+    Picasso.with(context)
+        .load(avatar)
+        .placeholder(
+            new Avatar(hostname, username).getTextDrawable(context))
+        .into(imageView);
+  }
+
+  private void setAliasInto(String alias, String username, TextView textView) {
+    final SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder();
+    final ForegroundColorSpan foregroundColorSpan = new ForegroundColorSpan(Color.BLACK);
+
+    spannableStringBuilder.append(alias);
+
+    if (username != null) {
+      spannableStringBuilder.append(" @");
+      spannableStringBuilder.append(username);
+    }
+
+    spannableStringBuilder
+        .setSpan(foregroundColorSpan, 0, alias.length(), Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+
+    textView.setText(spannableStringBuilder);
   }
 
 }

--- a/app/src/main/java/chat/rocket/android/renderer/UserRenderer.java
+++ b/app/src/main/java/chat/rocket/android/renderer/UserRenderer.java
@@ -23,37 +23,23 @@ public class UserRenderer extends AbstractRenderer<User> {
   }
 
   /**
-   * show Avatar image.
+   * show Avatar image
    */
   public UserRenderer avatarInto(ImageView imageView, String hostname) {
-    return avatarInto(imageView, hostname, null);
-  }
-
-  /**
-   * show Avatar image - overriding the user default.
-   */
-  public UserRenderer avatarInto(ImageView imageView, String hostname, String avatar) {
     if (!shouldHandle(imageView)) {
       return this;
     }
 
-    if (!TextUtils.isEmpty(object.getUsername()) || !TextUtils.isEmpty(avatar)) {
-      new Avatar(hostname, object.getUsername(), avatar).into(imageView);
+    if (!TextUtils.isEmpty(object.getUsername())) {
+      new Avatar(hostname, object.getUsername()).into(imageView);
     }
     return this;
   }
 
   /**
-   * show Username in textView.
+   * show Username in textView
    */
   public UserRenderer usernameInto(TextView textView) {
-    return usernameInto(textView, null);
-  }
-
-  /**
-   * show Username in textView - adding the alias first.
-   */
-  public UserRenderer usernameInto(TextView textView, String alias) {
     if (!shouldHandle(textView)) {
       return this;
     }
@@ -61,17 +47,9 @@ public class UserRenderer extends AbstractRenderer<User> {
     final SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder();
     final ForegroundColorSpan foregroundColorSpan = new ForegroundColorSpan(Color.BLACK);
 
-    if (TextUtils.isEmpty(alias)) {
-      spannableStringBuilder.append(object.getUsername());
-      spannableStringBuilder.setSpan(foregroundColorSpan, 0, object.getUsername().length(),
-          Spannable.SPAN_INCLUSIVE_INCLUSIVE);
-    } else {
-      spannableStringBuilder.append(alias);
-      spannableStringBuilder.append(" @");
-      spannableStringBuilder.append(object.getUsername());
-      spannableStringBuilder
-          .setSpan(foregroundColorSpan, 0, alias.length(), Spannable.SPAN_INCLUSIVE_INCLUSIVE);
-    }
+    spannableStringBuilder.append(object.getUsername());
+    spannableStringBuilder.setSpan(foregroundColorSpan, 0, object.getUsername().length(),
+        Spannable.SPAN_INCLUSIVE_INCLUSIVE);
 
     textView.setText(spannableStringBuilder);
 

--- a/app/src/main/java/chat/rocket/android/renderer/UserRenderer.java
+++ b/app/src/main/java/chat/rocket/android/renderer/UserRenderer.java
@@ -1,6 +1,10 @@
 package chat.rocket.android.renderer;
 
 import android.content.Context;
+import android.graphics.Color;
+import android.text.Spannable;
+import android.text.SpannableStringBuilder;
+import android.text.style.ForegroundColorSpan;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -22,12 +26,19 @@ public class UserRenderer extends AbstractRenderer<User> {
    * show Avatar image.
    */
   public UserRenderer avatarInto(ImageView imageView, String hostname) {
+    return avatarInto(imageView, hostname, null);
+  }
+
+  /**
+   * show Avatar image - overriding the user default.
+   */
+  public UserRenderer avatarInto(ImageView imageView, String hostname, String avatar) {
     if (!shouldHandle(imageView)) {
       return this;
     }
 
-    if (!TextUtils.isEmpty(object.getUsername())) {
-      new Avatar(hostname, object.getUsername()).into(imageView);
+    if (!TextUtils.isEmpty(object.getUsername()) || !TextUtils.isEmpty(avatar)) {
+      new Avatar(hostname, object.getUsername(), avatar).into(imageView);
     }
     return this;
   }
@@ -36,11 +47,34 @@ public class UserRenderer extends AbstractRenderer<User> {
    * show Username in textView.
    */
   public UserRenderer usernameInto(TextView textView) {
+    return usernameInto(textView, null);
+  }
+
+  /**
+   * show Username in textView - adding the alias first.
+   */
+  public UserRenderer usernameInto(TextView textView, String alias) {
     if (!shouldHandle(textView)) {
       return this;
     }
 
-    textView.setText(object.getUsername());
+    final SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder();
+    final ForegroundColorSpan foregroundColorSpan = new ForegroundColorSpan(Color.BLACK);
+
+    if (TextUtils.isEmpty(alias)) {
+      spannableStringBuilder.append(object.getUsername());
+      spannableStringBuilder.setSpan(foregroundColorSpan, 0, object.getUsername().length(),
+          Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+    } else {
+      spannableStringBuilder.append(alias);
+      spannableStringBuilder.append(" @");
+      spannableStringBuilder.append(object.getUsername());
+      spannableStringBuilder
+          .setSpan(foregroundColorSpan, 0, alias.length(), Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+    }
+
+    textView.setText(spannableStringBuilder);
+
     return this;
   }
 

--- a/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/message/MessageAttachmentFieldLayout.java
+++ b/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/message/MessageAttachmentFieldLayout.java
@@ -1,0 +1,65 @@
+package chat.rocket.android.widget.message;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.emojione.Emojione;
+
+import chat.rocket.android.widget.R;
+import chat.rocket.android.widget.helper.InlineHightlighter;
+import chat.rocket.android.widget.helper.Linkify;
+import chat.rocket.android.widget.helper.MarkDown;
+
+public class MessageAttachmentFieldLayout extends LinearLayout {
+
+  private TextView titleView;
+  private TextView valueView;
+
+  public MessageAttachmentFieldLayout(Context context) {
+    super(context);
+    initialize(context, null);
+  }
+
+  public MessageAttachmentFieldLayout(Context context, AttributeSet attrs) {
+    super(context, attrs);
+    initialize(context, attrs);
+  }
+
+  public MessageAttachmentFieldLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    initialize(context, attrs);
+  }
+
+  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+  public MessageAttachmentFieldLayout(Context context, AttributeSet attrs, int defStyleAttr,
+                                      int defStyleRes) {
+    super(context, attrs, defStyleAttr, defStyleRes);
+    initialize(context, attrs);
+  }
+
+  private void initialize(Context context, AttributeSet attrs) {
+    setOrientation(VERTICAL);
+    LayoutInflater.from(context)
+        .inflate(R.layout.message_inline_attachment_field, this, true);
+
+    titleView = (TextView) findViewById(R.id.field_title);
+    valueView = (TextView) findViewById(R.id.field_value);
+  }
+
+  public void setTitle(String title) {
+    titleView.setText(title);
+  }
+
+  public void setValue(String value) {
+    valueView.setText(Emojione.shortnameToUnicode(value, false));
+
+    MarkDown.apply(valueView);
+    Linkify.markup(valueView);
+    InlineHightlighter.highlight(valueView);
+  }
+}

--- a/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/message/RocketChatMessageLayout.java
+++ b/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/message/RocketChatMessageLayout.java
@@ -75,6 +75,10 @@ public class RocketChatMessageLayout extends LinearLayout {
   }
 
   private void appendTextView(String text) {
+    if (TextUtils.isEmpty(text)) {
+      return;
+    }
+
     TextView textView = (TextView) inflater.inflate(R.layout.message_body, this, false);
     textView.setText(Emojione.shortnameToUnicode(text, false));
 

--- a/rocket-chat-android-widgets/src/main/res/layout/message_inline_attachment.xml
+++ b/rocket-chat-android-widgets/src/main/res/layout/message_inline_attachment.xml
@@ -1,41 +1,109 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:layout_margin="4dp"
-        android:padding="4dp">
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp">
 
     <View
+            android:id="@+id/attachment_strip"
             android:layout_width="3dp"
             android:layout_height="match_parent"
             android:layout_marginRight="5dp"
             android:background="@color/inline_attachment_quote_line" />
 
     <LinearLayout
+            android:id="@+id/attachment_content"
             android:layout_width="0px"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:orientation="vertical">
 
+        <LinearLayout
+                android:id="@+id/author_box"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:layout_marginBottom="8dp">
+
+            <ImageView
+                    android:id="@+id/author_icon"
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    tools:src="@drawable/circle_black" />
+
+            <android.support.v4.widget.Space
+                    android:layout_width="8dp"
+                    android:layout_height="8dp" />
+
+            <TextView
+                    android:id="@+id/author_name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAppearance="@style/TextAppearance.RocketChat.MessageAttachment.Title.Link"
+                    tools:text="Bradley Hilton" />
+
+            <android.support.v4.widget.Space
+                    android:layout_width="8dp"
+                    android:layout_height="8dp" />
+
+            <TextView
+                    android:id="@+id/timestamp"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    tools:text="14:53" />
+
+        </LinearLayout>
+
         <TextView
                 android:id="@+id/title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="2dp"
-                android:layout_marginBottom="2dp"
+                android:layout_marginBottom="8dp"
                 android:textAppearance="@style/TextAppearance.RocketChat.MessageAttachment.Title"
-                android:background="?attr/selectableItemBackground" />
+                android:background="?attr/selectableItemBackground"
+                tools:text="Attachment Example" />
+
+        <LinearLayout
+                android:id="@+id/ref_box"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:layout_marginBottom="8dp">
+
+            <ImageView
+                    android:id="@+id/thumb"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    tools:src="@drawable/circle_black" />
+
+            <android.support.v4.widget.Space
+                    android:layout_width="8dp"
+                    android:layout_height="8dp" />
+
+            <TextView
+                    android:id="@+id/text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    tools:text="Bradley Hilton" />
+
+        </LinearLayout>
 
         <ImageView
                 android:id="@+id/image"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:maxHeight="200dp"
-                android:layout_marginTop="4dp"
-                android:layout_marginRight="8dp"
+                android:layout_marginBottom="8dp"
                 android:adjustViewBounds="true"
                 android:scaleType="fitStart" />
+
+        <!-- audio -->
+        <!-- video -->
 
     </LinearLayout>
 </LinearLayout>

--- a/rocket-chat-android-widgets/src/main/res/layout/message_inline_attachment_field.xml
+++ b/rocket-chat-android-widgets/src/main/res/layout/message_inline_attachment_field.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+    <TextView
+            android:id="@+id/field_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:textColor="@android:color/black"
+            tools:text="Test" />
+
+    <TextView
+            android:id="@+id/field_value"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:text="Test" />
+
+</LinearLayout>

--- a/rocket-chat-android-widgets/src/main/res/layout/message_inline_attachment_field.xml
+++ b/rocket-chat-android-widgets/src/main/res/layout/message_inline_attachment_field.xml
@@ -9,8 +9,7 @@
             android:id="@+id/field_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textStyle="bold"
-            android:textColor="@android:color/black"
+            android:textAppearance="@style/TextAppearance.RocketChat.MessageAttachment.Field.Title"
             tools:text="Test" />
 
     <TextView

--- a/rocket-chat-android-widgets/src/main/res/values/message_styles.xml
+++ b/rocket-chat-android-widgets/src/main/res/values/message_styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="TextAppearance.RocketChat" parent="TextAppearance.AppCompat"/>
+    <style name="TextAppearance.RocketChat" parent="TextAppearance.AppCompat" />
 
     <style name="TextAppearance.RocketChat.MessageBody" parent="TextAppearance.AppCompat.Body1">
 
@@ -13,13 +13,13 @@
         <item name="android:textStyle">bold</item>
     </style>
 
-    <style name="TextAppearance.RocketChat.MessageAttachment" parent="TextAppearance.AppCompat.Body1"/>
+    <style name="TextAppearance.RocketChat.MessageAttachment" parent="TextAppearance.AppCompat.Body1" />
 
     <style name="TextAppearance.RocketChat.MessageAttachment.Title" parent="TextAppearance.AppCompat.Title">
         <item name="android:textSize">14sp</item>
     </style>
 
-    <style name="TextAppearance.RocketChat.MessageAttachment.Title.Link" parent="TextAppearance.RocketChat.MessageAttachment.Title">
+    <style name="TextAppearance.RocketChat.MessageAttachment.Title.Link">
         <item name="android:textColor">?android:attr/textColorLink</item>
     </style>
 
@@ -27,9 +27,13 @@
         <item name="android:textSize">12sp</item>
     </style>
 
-    <style name="TextAppearance.RocketChat.MessageAttachment.Hostname"
-            parent="TextAppearance.AppCompat.Caption">
+    <style name="TextAppearance.RocketChat.MessageAttachment.Hostname" parent="TextAppearance.AppCompat.Caption">
         <item name="android:textSize">8sp</item>
+    </style>
+
+    <style name="TextAppearance.RocketChat.MessageAttachment.Field.Title" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textStyle">bold</item>
+        <item name="android:textColor">@android:color/black</item>
     </style>
 
     <color name="highlight_text_color">#333</color>

--- a/rocket-chat-android-widgets/src/main/res/values/message_styles.xml
+++ b/rocket-chat-android-widgets/src/main/res/values/message_styles.xml
@@ -17,6 +17,9 @@
 
     <style name="TextAppearance.RocketChat.MessageAttachment.Title" parent="TextAppearance.AppCompat.Title">
         <item name="android:textSize">14sp</item>
+    </style>
+
+    <style name="TextAppearance.RocketChat.MessageAttachment.Title.Link" parent="TextAppearance.RocketChat.MessageAttachment.Title">
         <item name="android:textColor">?android:attr/textColorLink</item>
     </style>
 


### PR DESCRIPTION
@RocketChat/android

Closes #169 

This is not a final solution since there are some missing points:

- audio attachments
- video attachments
- show the timestamp
- make attachment collapse
- have a thumb for image and opening the full image at a touch
- respect mobile option from settings

Audio and video will need a special solution for each case (with embedded players and so).
The timestamp depends on formatters not available at the module. Instead of copying it or whatever, maybe it would be better to deal with the data better (maybe using MVP).
The collapse behavior may be easy to do. Not sure about that.
Show an image thumb and show the full image is too complex and should have a task of it own.
Respect settings should be a task of it own.

![screenshot_1485192648](https://cloud.githubusercontent.com/assets/1779545/22215817/e472bf28-e183-11e6-9193-b8c7c58efc0f.png)

