### PR TITLE
fix issue that sendMessage error not notified properly

### DIFF
--- a/android-ddp/src/main/java/chat/rocket/android_ddp/DDPClientImpl.java
+++ b/android-ddp/src/main/java/chat/rocket/android_ddp/DDPClientImpl.java
@@ -134,6 +134,8 @@ public class DDPClientImpl {
               }));
 
       addErrorCallback(subscriptions, task);
+    } else {
+      task.trySetError(new DDPClientCallback.Closed(client));
     }
   }
 
@@ -174,6 +176,8 @@ public class DDPClientImpl {
               }));
 
       addErrorCallback(subscriptions, task);
+    } else {
+      task.trySetError(new DDPClientCallback.Closed(client));
     }
   }
 
@@ -202,6 +206,8 @@ public class DDPClientImpl {
               }));
 
       addErrorCallback(subscriptions, task);
+    } else {
+      task.trySetError(new DDPClientCallback.Closed(client));
     }
   }
 
@@ -241,6 +247,8 @@ public class DDPClientImpl {
               }));
 
       addErrorCallback(subscriptions, task);
+    } else {
+      task.trySetError(new DDPClientCallback.Closed(client));
     }
   }
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

After upgrading okhttp 3.5, `sendMessage` just returns `false` when WebSocket is already closed, and no exception is thrown then.
It should be handled manually for implementing reconnect feature properly.