### PR TITLE
improve the logic to render username and message alias

### DIFF
--- a/app/src/main/java/chat/rocket/android/layouthelper/chatroom/AbstractMessageViewHolder.java
+++ b/app/src/main/java/chat/rocket/android/layouthelper/chatroom/AbstractMessageViewHolder.java
@@ -14,6 +14,7 @@ import chat.rocket.android.realm_helper.RealmModelViewHolder;
 public abstract class AbstractMessageViewHolder extends RealmModelViewHolder<PairedMessage> {
   protected final ImageView avatar;
   protected final TextView username;
+  protected final TextView subUsername;
   protected final TextView timestamp;
   protected final View userAndTimeContainer;
   protected final String hostname;
@@ -29,6 +30,7 @@ public abstract class AbstractMessageViewHolder extends RealmModelViewHolder<Pai
     super(itemView);
     avatar = (ImageView) itemView.findViewById(R.id.user_avatar);
     username = (TextView) itemView.findViewById(R.id.username);
+    subUsername = (TextView) itemView.findViewById(R.id.sub_username);
     timestamp = (TextView) itemView.findViewById(R.id.timestamp);
     userAndTimeContainer = itemView.findViewById(R.id.user_and_timestamp_container);
     newDayContainer = itemView.findViewById(R.id.newday_container);

--- a/app/src/main/java/chat/rocket/android/layouthelper/chatroom/MessageNormalViewHolder.java
+++ b/app/src/main/java/chat/rocket/android/layouthelper/chatroom/MessageNormalViewHolder.java
@@ -31,7 +31,7 @@ public class MessageNormalViewHolder extends AbstractMessageViewHolder {
   protected void bindMessage(PairedMessage pairedMessage) {
     new MessageRenderer(itemView.getContext(), pairedMessage.target)
         .avatarInto(avatar, hostname)
-        .usernameInto(username)
+        .usernameInto(username, subUsername)
         .timestampInto(timestamp)
         .bodyInto(body)
         .urlsInto(urls)

--- a/app/src/main/java/chat/rocket/android/layouthelper/chatroom/MessageSystemViewHolder.java
+++ b/app/src/main/java/chat/rocket/android/layouthelper/chatroom/MessageSystemViewHolder.java
@@ -24,7 +24,7 @@ public class MessageSystemViewHolder extends AbstractMessageViewHolder {
   protected void bindMessage(PairedMessage pairedMessage) {
     new MessageRenderer(itemView.getContext(), pairedMessage.target)
         .avatarInto(avatar, hostname)
-        .usernameInto(username)
+        .usernameInto(username, subUsername)
         .timestampInto(timestamp);
 
     if (pairedMessage.target != null) {

--- a/app/src/main/java/chat/rocket/android/renderer/MessageRenderer.java
+++ b/app/src/main/java/chat/rocket/android/renderer/MessageRenderer.java
@@ -1,14 +1,9 @@
 package chat.rocket.android.renderer;
 
 import android.content.Context;
-import android.graphics.Color;
-import android.text.Spannable;
-import android.text.SpannableStringBuilder;
-import android.text.style.ForegroundColorSpan;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
-
 import com.squareup.picasso.Picasso;
 
 import chat.rocket.android.R;
@@ -53,12 +48,14 @@ public class MessageRenderer extends AbstractRenderer<Message> {
   /**
    * show Username in textView.
    */
-  public MessageRenderer usernameInto(TextView textView) {
+  public MessageRenderer usernameInto(TextView usernameTextView, TextView subUsernameTextView) {
     if (TextUtils.isEmpty(object.getAlias())) {
-      userRenderer.usernameInto(textView);
+      userRenderer.usernameInto(usernameTextView);
+      if (subUsernameTextView != null) {
+        subUsernameTextView.setVisibility(View.GONE);
+      }
     } else {
-      final User user = object.getUser();
-      setAliasInto(object.getAlias(), user == null ? null : user.getUsername(), textView);
+      aliasAndUsernameInto(usernameTextView, subUsernameTextView);
     }
     return this;
   }
@@ -146,21 +143,19 @@ public class MessageRenderer extends AbstractRenderer<Message> {
         .into(imageView);
   }
 
-  private void setAliasInto(String alias, String username, TextView textView) {
-    final SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder();
-    final ForegroundColorSpan foregroundColorSpan = new ForegroundColorSpan(Color.BLACK);
-
-    spannableStringBuilder.append(alias);
-
-    if (username != null) {
-      spannableStringBuilder.append(" @");
-      spannableStringBuilder.append(username);
+  private void aliasAndUsernameInto(TextView aliasTextView, TextView usernameTextView) {
+    if (shouldHandle(aliasTextView)) {
+      aliasTextView.setText(object.getAlias());
     }
 
-    spannableStringBuilder
-        .setSpan(foregroundColorSpan, 0, alias.length(), Spannable.SPAN_INCLUSIVE_INCLUSIVE);
-
-    textView.setText(spannableStringBuilder);
+    if (shouldHandle(usernameTextView)) {
+      if (object.getUser() != null) {
+        usernameTextView.setText("@" + object.getUser().getUsername());
+        usernameTextView.setVisibility(View.VISIBLE);
+      } else {
+        usernameTextView.setVisibility(View.GONE);
+      }
+    }
   }
 
 }

--- a/app/src/main/java/chat/rocket/android/renderer/UserRenderer.java
+++ b/app/src/main/java/chat/rocket/android/renderer/UserRenderer.java
@@ -1,10 +1,6 @@
 package chat.rocket.android.renderer;
 
 import android.content.Context;
-import android.graphics.Color;
-import android.text.Spannable;
-import android.text.SpannableStringBuilder;
-import android.text.style.ForegroundColorSpan;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -44,14 +40,7 @@ public class UserRenderer extends AbstractRenderer<User> {
       return this;
     }
 
-    final SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder();
-    final ForegroundColorSpan foregroundColorSpan = new ForegroundColorSpan(Color.BLACK);
-
-    spannableStringBuilder.append(object.getUsername());
-    spannableStringBuilder.setSpan(foregroundColorSpan, 0, object.getUsername().length(),
-        Spannable.SPAN_INCLUSIVE_INCLUSIVE);
-
-    textView.setText(spannableStringBuilder);
+    textView.setText(object.getUsername());
 
     return this;
   }

--- a/app/src/main/res/layout/list_item_normal_message.xml
+++ b/app/src/main/res/layout/list_item_normal_message.xml
@@ -39,8 +39,19 @@
                         android:id="@+id/username"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:textStyle="bold"
+                        android:textAppearance="@style/TextAppearance.RocketChat.Message.Username"
                         tools:text="John Doe" />
+
+                <Space
+                        android:layout_width="4dp"
+                        android:layout_height="wrap_content" />
+
+                <TextView
+                        android:id="@+id/sub_username"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="@style/TextAppearance.RocketChat.Message.SubUsername"
+                        tools:text="\@John Doe" />
 
                 <Space
                         android:layout_width="@dimen/margin_8"

--- a/app/src/main/res/layout/list_item_system_message.xml
+++ b/app/src/main/res/layout/list_item_system_message.xml
@@ -38,7 +38,7 @@
                         android:id="@+id/username"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:textStyle="bold"
+                        android:textAppearance="@style/TextAppearance.RocketChat.Message.Username"
                         tools:text="John Doe" />
 
                 <Space

--- a/app/src/main/res/values/message_styles.xml
+++ b/app/src/main/res/values/message_styles.xml
@@ -2,4 +2,10 @@
 <resources>
     <color name="newday_color">#e0e0e0</color>
     <color name="newday_text_color">#444444</color>
+    <style name="TextAppearance.RocketChat.Message.Username" parent="TextAppearance.AppCompat.Body2">
+        <item name="android:textColor">#bb000000</item>
+    </style>
+    <style name="TextAppearance.RocketChat.Message.SubUsername" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">#5f000000</item>
+    </style>
 </resources>


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

Originally, MessageRenderer and UserRenderer set both text contents and text styles.
However for example, if a TextView is put on the dark background, the textColor should be white instead of black.
So, it would be better that render just put text contents into TextView, and style is set in layout xml.

This PR adds "sub_username" TextView and changes the logic for rendering alias and username as below:

![image](https://cloud.githubusercontent.com/assets/11763113/22284194/6081fd9e-e329-11e6-9706-e8878f1b1447.png)
