### PR TITLE
Fix incorrect behavior

### DIFF
--- a/app/src/main/java/chat/rocket/android/api/MethodCallHelper.java
+++ b/app/src/main/java/chat/rocket/android/api/MethodCallHelper.java
@@ -317,8 +317,17 @@ public class MethodCallHelper {
    */
   private Task<JSONObject> sendMessage(final JSONObject messageJson) {
     return call("sendMessage", TIMEOUT_MS, () -> new JSONArray().put(messageJson))
-        .onSuccessTask(CONVERT_TO_JSON_OBJECT)
-        .onSuccessTask(task -> Task.forResult(Message.customizeJson(task.getResult())));
+        .onSuccessTask(task -> {
+          final String result = task.getResult();
+          if (result.equals("")) {
+            // valid success result
+            return Task.forResult(new JSONObject());
+          }
+
+          // should validate any other response
+          final JSONObject jsonObject = new JSONObject(result);
+          return Task.forResult(Message.customizeJson(jsonObject));
+        });
   }
 
   /**

--- a/app/src/main/java/chat/rocket/android/api/MethodCallHelper.java
+++ b/app/src/main/java/chat/rocket/android/api/MethodCallHelper.java
@@ -301,7 +301,7 @@ public class MethodCallHelper {
   /**
    * send message.
    */
-  public Task<JSONObject> sendMessage(String messageId, String roomId, String msg) {
+  public Task<Void> sendMessage(String messageId, String roomId, String msg) {
     try {
       return sendMessage(new JSONObject()
           .put("_id", messageId)
@@ -315,19 +315,9 @@ public class MethodCallHelper {
   /**
    * Send message object.
    */
-  private Task<JSONObject> sendMessage(final JSONObject messageJson) {
+  private Task<Void> sendMessage(final JSONObject messageJson) {
     return call("sendMessage", TIMEOUT_MS, () -> new JSONArray().put(messageJson))
-        .onSuccessTask(task -> {
-          final String result = task.getResult();
-          if (result.equals("")) {
-            // valid success result
-            return Task.forResult(new JSONObject());
-          }
-
-          // should validate any other response
-          final JSONObject jsonObject = new JSONObject(result);
-          return Task.forResult(Message.customizeJson(jsonObject));
-        });
+        .onSuccessTask(task -> Task.forResult(null));
   }
 
   /**

--- a/app/src/main/java/chat/rocket/android/service/observer/NewMessageObserver.java
+++ b/app/src/main/java/chat/rocket/android/service/observer/NewMessageObserver.java
@@ -53,7 +53,7 @@ public class NewMessageObserver extends AbstractModelObserver<Message> {
       return;
     }
 
-    Message message = results.get(0);
+    final Message message = results.get(0);
     final String messageId = message.getId();
     final String roomId = message.getRoomId();
     final String msg = message.getMessage();
@@ -63,13 +63,7 @@ public class NewMessageObserver extends AbstractModelObserver<Message> {
             .put(Message.ID, messageId)
             .put(Message.SYNC_STATE, SyncState.SYNCING)
         )
-    ).onSuccessTask(task ->
-        methodCall.sendMessage(messageId, roomId, msg).onSuccessTask(_task -> {
-          JSONObject messageJson = _task.getResult();
-          messageJson.put("syncstate", SyncState.SYNCED);
-          return realmHelper.executeTransaction(realm ->
-              realm.createOrUpdateObjectFromJson(Message.class, messageJson));
-        })
+    ).onSuccessTask(task -> methodCall.sendMessage(messageId, roomId, msg)
     ).continueWith(task -> {
       if (task.isFaulted()) {
         RCLog.w(task.getError());


### PR DESCRIPTION
@RocketChat/android

Closes #185 

We're setting the message sync state in several places and that generates a racing condition. Sometimes the correct result would show up.

The problem lies with the success response for sending a message: it has an empty message.

I added a special clause to that and removed the sync setter from `NewMessageObserver`. We may rely the one from `stream-room-messages`.