### PR TITLE
fix issue that getOrCreateWebSocket is unexpectedly called repeatedly.

### DIFF
--- a/app/src/main/java/chat/rocket/android/service/RealmBasedConnectivityManager.java
+++ b/app/src/main/java/chat/rocket/android/service/RealmBasedConnectivityManager.java
@@ -191,7 +191,7 @@ import rx.subjects.PublishSubject;
         .flatMap(state ->
             state == ServerConnectivity.STATE_CONNECTED
                 ? Single.just(true)
-                : Single.error(new ServerConnectivity.Disconnected()));
+                : Single.error(new ServerConnectivity.DisconnectedException()));
   }
 
   private Single<Boolean> waitForDisconnected(String hostname) {

--- a/app/src/main/java/chat/rocket/android/service/RealmBasedConnectivityManager.java
+++ b/app/src/main/java/chat/rocket/android/service/RealmBasedConnectivityManager.java
@@ -213,7 +213,7 @@ import rx.subjects.PublishSubject;
 
       if (serverConnectivityList.get(hostname) != ServerConnectivity.STATE_CONNECTED) {
         // Mark as CONNECTING except for the case [forceConnect && connected] because
-        // webSocketThread#keepAlive doesn't notify ConnectionEstablished/Lost on reconnecting.
+        // ensureConnectionToServer doesn't notify ConnectionEstablished/Lost is already connected.
         serverConnectivityList.put(hostname, ServerConnectivity.STATE_CONNECTING);
       }
 

--- a/app/src/main/java/chat/rocket/android/service/RealmBasedConnectivityManager.java
+++ b/app/src/main/java/chat/rocket/android/service/RealmBasedConnectivityManager.java
@@ -64,9 +64,7 @@ import rx.subjects.PublishSubject;
   @Override
   public void ensureConnections() {
     for (String hostname : serverConnectivityList.keySet()) {
-      connectToServer(hostname) //force connect.
-          //.doOnError(RCLog::e)
-          .retryWhen(RxHelper.exponentialBackoff(3, 500, TimeUnit.MILLISECONDS))
+      connectToServerIfNeeded(hostname, true/* force connect */)
           .subscribe(_val -> { }, RCLog::e);
     }
   }
@@ -78,7 +76,7 @@ import rx.subjects.PublishSubject;
     if (!serverConnectivityList.containsKey(hostname)) {
       serverConnectivityList.put(hostname, ServerConnectivity.STATE_DISCONNECTED);
     }
-    connectToServerIfNeeded(hostname)
+    connectToServerIfNeeded(hostname, false)
         .subscribe(_val -> { }, RCLog::e);
   }
 
@@ -93,7 +91,7 @@ import rx.subjects.PublishSubject;
 
   @Override
   public Single<Boolean> connect(String hostname) {
-    return connectToServerIfNeeded(hostname);
+    return connectToServerIfNeeded(hostname, false);
   }
 
   @Override
@@ -136,16 +134,16 @@ import rx.subjects.PublishSubject;
     return Observable.concat(Observable.from(getCurrentConnectivityList()), connectivitySubject);
   }
 
-  private Single<Boolean> connectToServerIfNeeded(String hostname) {
+  private Single<Boolean> connectToServerIfNeeded(String hostname, boolean forceConnect) {
     return Single.defer(() -> {
       final int connectivity = serverConnectivityList.get(hostname);
-      if (connectivity == ServerConnectivity.STATE_CONNECTED) {
+      if (!forceConnect && connectivity == ServerConnectivity.STATE_CONNECTED) {
         return Single.just(true);
       }
 
       if (connectivity == ServerConnectivity.STATE_DISCONNECTING) {
         return waitForDisconnected(hostname)
-            .flatMap(_val -> connectToServerIfNeeded(hostname));
+            .flatMap(_val -> connectToServerIfNeeded(hostname, forceConnect));
       }
 
       if (connectivity == ServerConnectivity.STATE_CONNECTING) {
@@ -167,6 +165,7 @@ import rx.subjects.PublishSubject;
 
       if (connectivity == ServerConnectivity.STATE_CONNECTING) {
         return waitForConnected(hostname)
+            .onErrorReturn(err -> true)
             .flatMap(_val -> disconnectFromServerIfNeeded(hostname));
       }
 
@@ -183,28 +182,40 @@ import rx.subjects.PublishSubject;
 
   private Single<Boolean> waitForConnected(String hostname) {
     return connectivitySubject
-        .filter(serverConnectivity -> (hostname.equals(serverConnectivity.hostname)
-            && serverConnectivity.state == ServerConnectivity.STATE_CONNECTED))
+        .filter(serverConnectivity -> hostname.equals(serverConnectivity.hostname))
+        .map(serverConnectivity -> serverConnectivity.state)
+        .filter(state ->
+            state == ServerConnectivity.STATE_CONNECTED || state == ServerConnectivity.STATE_DISCONNECTED)
         .first()
-        .map(serverConnectivity -> true)
-        .toSingle();
+        .toSingle()
+        .flatMap(state ->
+            state == ServerConnectivity.STATE_CONNECTED
+                ? Single.just(true)
+                : Single.error(new ServerConnectivity.Disconnected()));
   }
 
   private Single<Boolean> waitForDisconnected(String hostname) {
     return connectivitySubject
-        .filter(serverConnectivity -> (hostname.equals(serverConnectivity.hostname)
-            && serverConnectivity.state == ServerConnectivity.STATE_DISCONNECTED))
+        .filter(serverConnectivity -> hostname.equals(serverConnectivity.hostname))
+        .map(serverConnectivity -> serverConnectivity.state)
+        .filter(state -> state == ServerConnectivity.STATE_DISCONNECTED)
         .first()
-        .map(serverConnectivity -> true)
-        .toSingle();
+        .toSingle()
+        .map(state -> true);
   }
 
+  @DebugLog
   private Single<Boolean> connectToServer(String hostname) {
     return Single.defer(() -> {
       if (!serverConnectivityList.containsKey(hostname)) {
         return Single.error(new IllegalArgumentException("hostname not found"));
       }
-      serverConnectivityList.put(hostname, ServerConnectivity.STATE_CONNECTING);
+
+      if (serverConnectivityList.get(hostname) != ServerConnectivity.STATE_CONNECTED) {
+        // Mark as CONNECTING except for the case [forceConnect && connected] because
+        // webSocketThread#keepAlive doesn't notify ConnectionEstablished/Lost on reconnecting.
+        serverConnectivityList.put(hostname, ServerConnectivity.STATE_CONNECTING);
+      }
 
       if (serviceInterface != null) {
         return serviceInterface.ensureConnectionToServer(hostname);

--- a/app/src/main/java/chat/rocket/android/service/RocketChatService.java
+++ b/app/src/main/java/chat/rocket/android/service/RocketChatService.java
@@ -93,14 +93,8 @@ public class RocketChatService extends Service implements ConnectivityServiceInt
     return Single.defer(() -> {
       if (webSocketThreads.containsKey(hostname)) {
         RocketChatWebSocketThread thread = webSocketThreads.get(hostname);
-        if (thread != null) {
-          return Single.just(thread);
-        } else {
-          return Observable.timer(1, TimeUnit.SECONDS).toSingle()
-              .flatMap(_val -> getOrCreateWebSocketThread(hostname));
-        }
+        return Single.just(thread);
       }
-      webSocketThreads.put(hostname, null);
       return RocketChatWebSocketThread.getStarted(getApplicationContext(), hostname)
           .doOnSuccess(thread -> webSocketThreads.put(hostname, thread));
     });

--- a/app/src/main/java/chat/rocket/android/service/ServerConnectivity.java
+++ b/app/src/main/java/chat/rocket/android/service/ServerConnectivity.java
@@ -17,8 +17,11 @@ public class ServerConnectivity {
     this.state = state;
   }
 
-  public static class Disconnected extends Exception {
-    public Disconnected() {
+  /**
+   * This exception should be thrown when connection is lost during waiting for CONNECTED.
+   */
+  public static class DisconnectedException extends Exception {
+    public DisconnectedException() {
       super("Disconnected");
     }
   }

--- a/app/src/main/java/chat/rocket/android/service/ServerConnectivity.java
+++ b/app/src/main/java/chat/rocket/android/service/ServerConnectivity.java
@@ -16,4 +16,10 @@ public class ServerConnectivity {
     this.hostname = hostname;
     this.state = state;
   }
+
+  public static class Disconnected extends Exception {
+    public Disconnected() {
+      super("Disconnected");
+    }
+  }
 }


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
related to #137 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

```
02-05 23:54:49.170 V/RocketChatService( 2286): ⇠ getOrCreateWebSocketThread [0ms] = rx.Single@c20090d
02-05 23:54:49.350 V/RocketChatService( 2286): ⇢ getOrCreateWebSocketThread(hostname="demo.rocket.chat") [Thread:"RxComputationScheduler-1"]
02-05 23:54:49.351 V/RocketChatService( 2286): ⇠ getOrCreateWebSocketThread [0ms] = rx.Single@6ab9ed3
02-05 23:54:49.387 V/RocketChatService( 2286): ⇢ getOrCreateWebSocketThread(hostname="demo.rocket.chat") [Thread:"RxComputationScheduler-2"]
02-05 23:54:49.388 V/RocketChatService( 2286): ⇠ getOrCreateWebSocketThread [0ms] = rx.Single@5512909
02-05 23:54:50.171 V/RocketChatService( 2286): ⇢ getOrCreateWebSocketThread(hostname="demo.rocket.chat") [Thread:"RxComputationScheduler-3"]
02-05 23:54:50.172 V/RocketChatService( 2286): ⇠ getOrCreateWebSocketThread [0ms] = rx.Single@9cf45a0
02-05 23:54:50.230 D/RoomFragment( 2286): hasNext: true syncstate: 0
02-05 23:54:50.352 V/RocketChatService( 2286): ⇢ getOrCreateWebSocketThread(hostname="demo.rocket.chat") [Thread:"RxComputationScheduler-4"]
02-05 23:54:50.352 V/RocketChatService( 2286): ⇠ getOrCreateWebSocketThread [0ms] = rx.Single@d655af5
02-05 23:54:50.389 V/RocketChatService( 2286): ⇢ getOrCreateWebSocketThread(hostname="demo.rocket.chat") [Thread:"RxComputationScheduler-1"]
02-05 23:54:50.389 V/RocketChatService( 2286): ⇠ getOrCreateWebSocketThread [0ms] = rx.Single@88e7d30
02-05 23:54:50.528 V/RocketChatService( 2286): ⇢ getOrCreateWebSocketThread(hostname="demo.rocket.chat")
02-05 23:54:50.528 V/RocketChatService( 2286): ⇠ getOrCreateWebSocketThread [0ms] = rx.Single@6e984b5
02-05 23:54:51.173 V/RocketChatService( 2286): ⇢ getOrCreateWebSocketThread(hostname="demo.rocket.chat") [Thread:"RxComputationScheduler-2"]
02-05 23:54:51.173 V/RocketChatService( 2286): ⇠ getOrCreateWebSocketThread [0ms] = rx.Single@80266bb
02-05 23:54:51.353 V/RocketChatService( 2286): ⇢ getOrCreateWebSocketThread(hostname="demo.rocket.chat") [Thread:"RxComputationScheduler-3"]
02-05 23:54:51.353 V/RocketChatService( 2286): ⇠ getOrCreateWebSocketThread [0ms] = rx.Single@6fab731
02-05 23:54:51.390 V/RocketChatService( 2286): ⇢ getOrCreateWebSocketThread(hostname="demo.rocket.chat") [Thread:"RxComputationScheduler-4"]
02-05 23:54:51.391 V/RocketChatService( 2286): ⇠ getOrCreateWebSocketThread [0ms] = rx.Single@1e6b397
02-05 23:54:51.530 V/RocketChatService( 2286): ⇢ getOrCreateWebSocketThread(hostname="demo.rocket.chat") [Thread:"RxComputationScheduler-1"]
02-05 23:54:51.531 V/RocketChatService( 2286): ⇠ getOrCreateWebSocketThread [0ms] = rx.Single@712956d
02-05 23:54:52.175 V/RocketChatService( 2286): ⇢ getOrCreateWebSocketThread(hostname="demo.rocket.chat") [Thread:"RxComputationScheduler-2"]
02-05 23:54:52.177 V/RocketChatService( 2286): ⇠ getOrCreateWebSocketThread [0ms] = rx.Single@158f233
02-05 23:54:52.358 V/RocketChatService( 2286): ⇢ getOrCreateWebSocketThread(hostname="demo.rocket.chat") [Thread:"RxComputationScheduler-3"]
02-05 23:54:52.359 V/RocketChatService( 2286): ⇠ getOrCreateWebSocketThread [0ms] = rx.Single@d501b69
02-05 23:54:52.393 V/RocketChatService( 2286): ⇢ getOrCreateWebSocketThread(hostname="demo.rocket.chat") [Thread:"RxComputationScheduler-4"]
02-05 23:54:52.394 V/RocketChatService( 2286): ⇠ getOrCreateWebSocketThread [0ms] = rx.Single@4a67e8f
02-05 23:54:52.534 V/RocketChatService( 2286): ⇢ getOrCreateWebSocketThread(hostname="demo.rocket.chat") [Thread:"RxComputationScheduler-1"]
02-05 23:54:52.535 V/RocketChatService( 2286): ⇠ getOrCreateWebSocketThread [0ms] = rx.Single@8c60525
02-05 23:54:53.179 V/RocketChatService( 2286): ⇢ getOrCreateWebSocketThread(hostname="demo.rocket.chat") [Thread:"RxComputationScheduler-2"]
02-05 23:54:53.181 V/RocketChatService( 2286): ⇠ getOrCreateWebSocketThread [0ms] = rx.Single@79674ab
02-05 23:54:53.362 V/RocketChatService( 2286): ⇢ getOrCreateWebSocketThread(hostname="demo.rocket.chat") [Thread:"RxComputationScheduler-3"]
```

* [just refactoring] Previously, `thread = null` was put in `webSocketThreads` during connecting to server. However it is really confusing that it has different lifecycle from ServerConnectivity.CONNECTING/CONNECTED. So this PR stops putting `thread = null` during connecting status. Just rely on `serverConnectivityList`.
* [root cause of this issue] Previously `connectivity = CONNECTING` was set every-time `RocketChatWebSocket#keepAlive()` is called. However `keepAlive()` doesn't notify `ConnectionEstablished()` when the connection is already established. So this PR stops putting `CONNECTING` when ServerConnectivityList already has `CONNECTED` status.