### PR TITLE
Fix notification and round avatar

### DIFF
--- a/app/src/main/java/chat/rocket/android/activity/AbstractAuthedActivity.java
+++ b/app/src/main/java/chat/rocket/android/activity/AbstractAuthedActivity.java
@@ -4,21 +4,21 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 
-import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.schedulers.Schedulers;
-
 import java.util.List;
+
 import chat.rocket.android.LaunchUtil;
 import chat.rocket.android.RocketChatCache;
 import chat.rocket.android.helper.Logger;
-import chat.rocket.persistence.realm.models.ddp.RealmRoom;
 import chat.rocket.android.push.PushConstants;
 import chat.rocket.android.push.PushNotificationHandler;
-import chat.rocket.persistence.realm.RealmStore;
 import chat.rocket.android.service.ConnectivityManager;
 import chat.rocket.core.models.ServerInfo;
+import chat.rocket.persistence.realm.RealmStore;
+import chat.rocket.persistence.realm.models.ddp.RealmRoom;
 import icepick.State;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.schedulers.Schedulers;
 
 abstract class AbstractAuthedActivity extends AbstractFragmentActivity {
   @State protected String hostname;
@@ -26,6 +26,7 @@ abstract class AbstractAuthedActivity extends AbstractFragmentActivity {
 
   private RocketChatCache rocketChatCache;
   private CompositeDisposable compositeDisposable = new CompositeDisposable();
+  private boolean isNotification;
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -61,6 +62,7 @@ abstract class AbstractAuthedActivity extends AbstractFragmentActivity {
     }
 
     if (intent.hasExtra(PushConstants.NOT_ID)) {
+      isNotification = true;
       PushNotificationHandler
           .cleanUpNotificationStack(intent.getIntExtra(PushConstants.NOT_ID, 0));
     }
@@ -155,6 +157,11 @@ abstract class AbstractAuthedActivity extends AbstractFragmentActivity {
     subscribeToConfigChanges();
 
     ConnectivityManager.getInstance(getApplicationContext()).keepAliveServer();
+    if (isNotification) {
+      updateHostnameIfNeeded(rocketChatCache.getSelectedServerHostname());
+      updateRoomIdIfNeeded(rocketChatCache.getSelectedRoomId());
+      isNotification = false;
+    }
   }
 
   @Override

--- a/app/src/main/java/chat/rocket/android/activity/MainActivity.java
+++ b/app/src/main/java/chat/rocket/android/activity/MainActivity.java
@@ -52,8 +52,8 @@ public class MainActivity extends AbstractAuthedActivity implements MainContract
   @Override
   protected void onResume() {
     super.onResume();
-    if (presenter != null && presenter instanceof MainPresenter) {
-      ((MainPresenter)presenter).bindViewOnly(this);
+    if (presenter != null) {
+      presenter.bindViewOnly(this);
     }
   }
 

--- a/app/src/main/java/chat/rocket/android/activity/MainContract.java
+++ b/app/src/main/java/chat/rocket/android/activity/MainContract.java
@@ -28,5 +28,7 @@ public interface MainContract {
     void onOpenRoom(String hostname, String roomId);
 
     void onRetryLogin();
+
+    void bindViewOnly(View view);
   }
 }

--- a/app/src/main/java/chat/rocket/android/activity/MainPresenter.java
+++ b/app/src/main/java/chat/rocket/android/activity/MainPresenter.java
@@ -44,6 +44,7 @@ public class MainPresenter extends BasePresenter<MainContract.View>
     this.rocketChatCache = rocketChatCache;
   }
 
+  @Override
   public void bindViewOnly(@NonNull MainContract.View view) {
     super.bindView(view);
     subscribeToUnreadCount();

--- a/rocket-chat-android-widgets/src/main/res/layout/message_avatar.xml
+++ b/rocket-chat-android-widgets/src/main/res/layout/message_avatar.xml
@@ -4,4 +4,5 @@
         android:id="@+id/drawee_avatar"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        fresco:actualImageScaleType="fitCenter" />
+        fresco:actualImageScaleType="fitCenter"
+        fresco:roundedCornerRadius="5dp" />


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #280 #279 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
When a user in the app, then they click notification. Activity will call onPause, then onNewIntent then onResume. But when onPause is called, the Subscription to rocketChatCache will be released and when onNewIntent call, the change of hostname, roomid will not be handle. So It won't open new room.
I've fixed it.