### PR TITLE
added fresco clear cache on app start

### DIFF
--- a/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/RocketChatWidgets.java
+++ b/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/RocketChatWidgets.java
@@ -23,5 +23,7 @@ public class RocketChatWidgets {
     ImageFormatConfigurator.addCustomDrawableFactories(draweeConfigBuilder);
 
     Fresco.initialize(context, config, draweeConfigBuilder.build());
+
+    Fresco.getImagePipeline().clearCaches();
   }
 }


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #251 

The lack of Fresco's cache clearing may result in old/wrong avatar displaying.

The previous merge request solved partially the issue.