### PR TITLE
moved OAuth webviews loading from onResume to onCreate

### DIFF
--- a/app/src/main/java/chat/rocket/android/fragment/oauth/AbstractOAuthFragment.java
+++ b/app/src/main/java/chat/rocket/android/fragment/oauth/AbstractOAuthFragment.java
@@ -6,10 +6,12 @@ import android.text.TextUtils;
 import android.util.Base64;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebView;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.nio.charset.Charset;
+
 import chat.rocket.android.api.MethodCallHelper;
 import chat.rocket.android.fragment.AbstractWebViewFragment;
 import chat.rocket.core.models.LoginServiceConfiguration;
@@ -61,13 +63,14 @@ public abstract class AbstractOAuthFragment extends AbstractWebViewFragment
         new RealmLoginServiceConfigurationRepository(hostname),
         new MethodCallHelper(getContext(), hostname)
     );
+
+    presenter.loadService(getOAuthServiceName());
   }
 
   @Override
   public void onResume() {
     super.onResume();
     presenter.bindView(this);
-    presenter.loadService(getOAuthServiceName());
   }
 
   @Override


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #293

When user is trying to login using OAuth (Github, Google...) and needs to open another app to complete authentication (2FA, for example), RC+ loses login state and user needs to login again.

Fixed by avoiding unnecessary reload of oauth webview (that's how integration with external auth services is done at this moment)