### PR TITLE
Bumped timeout from 4000 to 20000 ms as it seems a more reasonable

### DIFF
--- a/app/src/main/java/chat/rocket/android/api/MethodCallHelper.java
+++ b/app/src/main/java/chat/rocket/android/api/MethodCallHelper.java
@@ -36,7 +36,7 @@ import hugo.weaving.DebugLog;
  */
 public class MethodCallHelper {
 
-  protected static final long TIMEOUT_MS = 4000;
+  protected static final long TIMEOUT_MS = 20000;
   protected static final Continuation<String, Task<JSONObject>> CONVERT_TO_JSON_OBJECT =
       task -> Task.forResult(new JSONObject(task.getResult()));
   protected static final Continuation<String, Task<JSONArray>> CONVERT_TO_JSON_ARRAY =

--- a/app/src/main/java/chat/rocket/android/service/observer/NewMessageObserver.java
+++ b/app/src/main/java/chat/rocket/android/service/observer/NewMessageObserver.java
@@ -72,6 +72,11 @@ public class NewMessageObserver extends AbstractModelObserver<RealmMessage> {
             realm.createOrUpdateObjectFromJson(RealmMessage.class, new JSONObject()
                 .put(RealmMessage.ID, messageId)
                 .put(RealmMessage.SYNC_STATE, SyncState.FAILED)));
+      } else {
+        realmHelper.executeTransaction(realm ->
+                realm.createOrUpdateObjectFromJson(RealmMessage.class, new JSONObject()
+                        .put(RealmMessage.ID, messageId)
+                        .put(RealmMessage.SYNC_STATE, SyncState.SYNCED)));
       }
       return null;
     });


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Bumped timeout for rpc calls from 4000 to 20000 millis as it seems a more reasonable threshold.
    
Also updating a sending message sync state to SyncState.SYNCED at Realm in case a sending message is successfully sent.

This sync status update fix is related to issue #268 
