### PR TITLE
Fix crash when building default avatar 

### DIFF
--- a/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/helper/UserAvatarHelper.kt
+++ b/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/helper/UserAvatarHelper.kt
@@ -69,8 +69,11 @@ object UserAvatarHelper {
         }
 
         val splitUsername = username.split(".")
-        if (splitUsername.size > 1) {
-            return (splitUsername[0].substring(0, 1) + splitUsername[splitUsername.size - 1].substring(0, 1)).toUpperCase()
+        val splitCount = splitUsername.size
+        if (splitCount > 1 && splitUsername[0].isNotEmpty() && splitUsername[1].isNotEmpty()) {
+            val firstInitial = splitUsername[0].substring(0, 1)
+            val secondInitial = splitUsername[1].substring(0, 1)
+            return (firstInitial + secondInitial).toUpperCase()
         } else {
             if (username.length > 1) {
                 return username.substring(0, 2).toUpperCase()

--- a/rocket-chat-android-widgets/src/test/kotlin/chat/rocket/android/widget/helper/UserAvatarHelperTest.kt
+++ b/rocket-chat-android-widgets/src/test/kotlin/chat/rocket/android/widget/helper/UserAvatarHelperTest.kt
@@ -18,5 +18,9 @@ class UserAvatarHelperTest {
         assert(UserAvatarHelper.getUsernameInitials("Foo.bar") == "FB")
         assert(UserAvatarHelper.getUsernameInitials("Foobar.bar") == "FB")
         assert(UserAvatarHelper.getUsernameInitials("Foobar.bar.zab") == "FZ")
+        assert(UserAvatarHelper.getUsernameInitials("..") == "..")
+        assert(UserAvatarHelper.getUsernameInitials("...") == "..")
+        assert(UserAvatarHelper.getUsernameInitials(".Foo.") == ".F")
+        assert(UserAvatarHelper.getUsernameInitials("Foo..") == "FO")
     }
 }


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #390 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Crashes were happening when building the default avatar for users with unexpected dotted usernames such as "...", "..", ".Foo." or "Foo..".

This changes the behavior to get close to the web client. The above mentioned usernames will be rendered, respectively, as "..", "..", ".F" and "FO". The web client does almost the same with few differences, like when the username is "..." it renders as an empty avatar.