### PR TITLE
Fix on building the default avatar

### DIFF
--- a/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/helper/UserAvatarHelper.kt
+++ b/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/helper/UserAvatarHelper.kt
@@ -70,9 +70,9 @@ object UserAvatarHelper {
 
         val splitUsername = username.split(".")
         val splitCount = splitUsername.size
-        if (splitCount > 1 && splitUsername[0].isNotEmpty() && splitUsername[1].isNotEmpty()) {
+        if (splitCount > 1 && splitUsername[0].isNotEmpty() && splitUsername[splitCount-1].isNotEmpty()) {
             val firstInitial = splitUsername[0].substring(0, 1)
-            val secondInitial = splitUsername[1].substring(0, 1)
+            val secondInitial = splitUsername[splitCount-1].substring(0, 1)
             return (firstInitial + secondInitial).toUpperCase()
         } else {
             if (username.length > 1) {

--- a/rocket-chat-android-widgets/src/test/kotlin/chat/rocket/android/widget/helper/UserAvatarHelperTest.kt
+++ b/rocket-chat-android-widgets/src/test/kotlin/chat/rocket/android/widget/helper/UserAvatarHelperTest.kt
@@ -1,26 +1,27 @@
 import chat.rocket.android.widget.helper.UserAvatarHelper
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class UserAvatarHelperTest {
 
     @Test
     fun getUsernameInitialsTest() {
-        assert(UserAvatarHelper.getUsernameInitials("") == "?")
-        assert(UserAvatarHelper.getUsernameInitials("?") == "?")
-        assert(UserAvatarHelper.getUsernameInitials("f") == "F")
-        assert(UserAvatarHelper.getUsernameInitials("B") == "B")
-        assert(UserAvatarHelper.getUsernameInitials("fo") == "FO")
-        assert(UserAvatarHelper.getUsernameInitials("FO") == "FO")
-        assert(UserAvatarHelper.getUsernameInitials("fOo") == "FO")
-        assert(UserAvatarHelper.getUsernameInitials("FOO") == "FO")
-        assert(UserAvatarHelper.getUsernameInitials("F.O") == "FO")
-        assert(UserAvatarHelper.getUsernameInitials("F.o") == "FO")
-        assert(UserAvatarHelper.getUsernameInitials("Foo.bar") == "FB")
-        assert(UserAvatarHelper.getUsernameInitials("Foobar.bar") == "FB")
-        assert(UserAvatarHelper.getUsernameInitials("Foobar.bar.zab") == "FZ")
-        assert(UserAvatarHelper.getUsernameInitials("..") == "..")
-        assert(UserAvatarHelper.getUsernameInitials("...") == "..")
-        assert(UserAvatarHelper.getUsernameInitials(".Foo.") == ".F")
-        assert(UserAvatarHelper.getUsernameInitials("Foo..") == "FO")
+        assertEquals("?", UserAvatarHelper.getUsernameInitials(""))
+        assertEquals("?", UserAvatarHelper.getUsernameInitials("?"))
+        assertEquals("F", UserAvatarHelper.getUsernameInitials("f"))
+        assertEquals("B", UserAvatarHelper.getUsernameInitials("B"))
+        assertEquals("FO", UserAvatarHelper.getUsernameInitials("Fo"))
+        assertEquals("FO", UserAvatarHelper.getUsernameInitials("FO"))
+        assertEquals("FO", UserAvatarHelper.getUsernameInitials("fOo"))
+        assertEquals("FO", UserAvatarHelper.getUsernameInitials("FOO"))
+        assertEquals("FO", UserAvatarHelper.getUsernameInitials("F.O"))
+        assertEquals("FO", UserAvatarHelper.getUsernameInitials("F.o"))
+        assertEquals("FB", UserAvatarHelper.getUsernameInitials("Foo.bar"))
+        assertEquals("FB", UserAvatarHelper.getUsernameInitials("Foobar.bar"))
+        assertEquals("FZ", UserAvatarHelper.getUsernameInitials("Foobar.bar.zab"))
+        assertEquals("..", UserAvatarHelper.getUsernameInitials(".."))
+        assertEquals("..", UserAvatarHelper.getUsernameInitials("..."))
+        assertEquals(".F", UserAvatarHelper.getUsernameInitials(".Foo."))
+        assertEquals("FO", UserAvatarHelper.getUsernameInitials("Foo.."))
     }
 }


### PR DESCRIPTION
@RocketChat/android

We are facing a small issue on building the default avatar. This PR fix it. It also updates the related test class (note that before this PR, the test are fine even testing `"Hi"` w/ `"hello"` string).