### PR TITLE
[FIX] Fixes message history randomly missing from room

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,7 +47,7 @@ android {
         applicationId "chat.rocket.android"
         minSdkVersion 16
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 29
+        versionCode 30
         versionName "1.0.16"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,9 @@ apply plugin: 'io.fabric'
 
 repositories {
     maven { url 'https://maven.fabric.io/public' }
+    maven {
+        url 'https://github.com/uPhyca/stetho-realm/raw/master/maven-repo'
+    }
 }
 
 apply plugin: 'kotlin-android'
@@ -123,7 +126,7 @@ dependencies {
 
     compile "com.facebook.stetho:stetho:$stethoVersion"
     compile "com.facebook.stetho:stetho-okhttp3:$stethoVersion"
-    compile 'com.uphyca:stetho_realm:2.0.1'
+    compile 'com.uphyca:stetho_realm:2.1.0'
 
     compile "com.jakewharton.rxbinding2:rxbinding:$rxbindingVersion"
     compile "com.jakewharton.rxbinding2:rxbinding-support-v4:$rxbindingVersion"


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #403 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Upon receiving a "removed" message for a specific user which implies on him going offline was resulting on deleting that given user from Realm instead of just setting its presence status to offline.