### PR TITLE
[FIX] Message composer crashes

### DIFF
--- a/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/message/autocomplete/AutocompleteManager.java
+++ b/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/message/autocomplete/AutocompleteManager.java
@@ -220,6 +220,9 @@ public class AutocompleteManager {
   }
 
   private void replaceSelected(String autocompleteSuggestion) {
+    if (text == null) {
+      return;
+    }
     final String preText = text.substring(0, fromIndex);
     final String postText = text.substring(toIndex);
 

--- a/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/message/autocomplete/AutocompleteSource.java
+++ b/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/message/autocomplete/AutocompleteSource.java
@@ -12,7 +12,7 @@ public abstract class AutocompleteSource<A extends AutocompleteAdapter, I extend
       new AutocompleteViewHolder.OnClickListener<I>() {
         @Override
         public void onClick(I autocompleteItem) {
-          if (autocompleteSelected != null) {
+          if (autocompleteSelected != null && autocompleteItem != null) {
             autocompleteSelected.onSelected(getAutocompleteSuggestion(autocompleteItem));
           }
         }

--- a/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/message/autocomplete/user/UserSource.java
+++ b/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/message/autocomplete/user/UserSource.java
@@ -99,7 +99,7 @@ public class UserSource extends AutocompleteSource<UserAdapter, UserItem> {
 
   @Override
   protected String getAutocompleteSuggestion(UserItem autocompleteItem) {
-    return getTrigger() + autocompleteItem.getSuggestion();
+    return getTrigger() + (autocompleteItem == null ? "" : autocompleteItem.getSuggestion());
   }
 
   private List<UserItem> toUserItemList(List<SpotlightUser> users) {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Fixes two different crashes that happens on composer:

1. [https://www.fabric.io/rocketchat3/android/apps/chat.rocket.android/issues/599b4157be077a4dcc68ff22](https://www.fabric.io/rocketchat3/android/apps/chat.rocket.android/issues/599b4157be077a4dcc68ff22) Caught this bug when typing @ and quickly removing  the text after choosing a user from the autocomplete context menu.
2. Other one happens when a mention @ is typed and no user is found showing the empty view. The empty view is clickable and so the autocomplete manager tries to complete a mention with something that does not exist.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->