### PR TITLE
[FIX] Set client to use Cordova's project Sender Id when no token on Settings

### DIFF
--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,35 +1,27 @@
 {
   "project_info": {
-    "project_number": "361979207101",
-    "firebase_url": "https://rocketchatandroid-92e1e.firebaseio.com",
-    "project_id": "rocketchatandroid-92e1e",
-    "storage_bucket": "rocketchatandroid-92e1e.appspot.com"
+    "project_number": "1020987621558",
+    "firebase_url": "https://rocketchatnative.firebaseio.com",
+    "project_id": "rocketchatnative",
+    "storage_bucket": "rocketchatnative.appspot.com"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:361979207101:android:16da2e50aff9f0c9",
+        "mobilesdk_app_id": "1:1020987621558:android:16da2e50aff9f0c9",
         "android_client_info": {
           "package_name": "chat.rocket.android"
         }
       },
       "oauth_client": [
         {
-          "client_id": "361979207101-68jt4s85vqfidsgtb0jircio1s4l0la6.apps.googleusercontent.com",
-          "client_type": 1,
-          "android_info": {
-            "package_name": "chat.rocket.android",
-            "certificate_hash": "5540F34145397BBDE62DEE1433BE7FF9D991D5A2"
-          }
-        },
-        {
-          "client_id": "361979207101-tvvl8a3s98vd933svlepieo81mul17da.apps.googleusercontent.com",
+          "client_id": "1020987621558-trk61fjrahho0ujtjap095p1jmi48pfq.apps.googleusercontent.com",
           "client_type": 3
         }
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyCjInoCWiVXbC02aKgBPeH3EqiHGt6vGyE"
+          "current_key": "AIzaSyDc7VYUdU6kRkoRTToiCn1rh-W0wJvhLWk"
         }
       ],
       "services": {
@@ -37,13 +29,8 @@
           "status": 1
         },
         "appinvite_service": {
-          "status": 2,
-          "other_platform_oauth_client": [
-            {
-              "client_id": "361979207101-tvvl8a3s98vd933svlepieo81mul17da.apps.googleusercontent.com",
-              "client_type": 3
-            }
-          ]
+          "status": 1,
+          "other_platform_oauth_client": []
         },
         "ads_service": {
           "status": 2

--- a/app/src/main/res/values/apis_keys.xml
+++ b/app/src/main/res/values/apis_keys.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="gcm_sender_id">YOUR-SENDER-ID</string>
+    <string name="gcm_sender_id">673693445664</string>
 </resources>


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Fallback to using Cordova's sender id when no other on is set under the admin settings for the server. 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->