### PR TITLE
[PROJECT] Removed un-needed project dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,9 +128,7 @@ ext {
 }
 
 dependencies {
-    compile project(':log-wrapper')
     compile project(':android-ddp')
-    compile project(':rocket-chat-core')
     compile project(':rocket-chat-android-widgets')
     compile project(':persistence-realm')
 


### PR DESCRIPTION
This PR contains only some of the clean up of the gradle file by removing the un-needed dependencies


compile project(':log-wrapper') is already added under compile project(':android-ddp') and compile project(':persistence-realm') too.
compile project(':rocket-chat-core') is already added under compile project(':persistence-realm') and compile project(':rocket-chat-android-widgets')