### PR TITLE
[FIX] Fallback room type to group ("p") if admin adds a custom room type

### DIFF
--- a/app/src/main/java/chat/rocket/android/api/rest/RestApiHelper.kt
+++ b/app/src/main/java/chat/rocket/android/api/rest/RestApiHelper.kt
@@ -179,7 +179,7 @@ object RestApiHelper {
         var restApiUrl: String? = null
         when (roomType) {
             Room.TYPE_CHANNEL -> restApiUrl = "/api/v1/channels.messages"
-            Room.TYPE_PRIVATE -> restApiUrl = "/api/v1/groups.messages"
+            Room.TYPE_GROUP -> restApiUrl = "/api/v1/groups.messages"
             Room.TYPE_DIRECT_MESSAGE -> restApiUrl = "/api/v1/dm.messages"
         }
         return restApiUrl
@@ -195,7 +195,7 @@ object RestApiHelper {
         var restApiUrl: String? = null
         when (roomType) {
             Room.TYPE_CHANNEL -> restApiUrl = "/api/v1/channels.files"
-            Room.TYPE_PRIVATE -> restApiUrl = "/api/v1/groups.files"
+            Room.TYPE_GROUP -> restApiUrl = "/api/v1/groups.files"
             Room.TYPE_DIRECT_MESSAGE -> restApiUrl = "/api/v1/dm.files"
         }
         return restApiUrl
@@ -211,7 +211,7 @@ object RestApiHelper {
         var restApiUrl: String? = null
         when (roomType) {
             Room.TYPE_CHANNEL -> restApiUrl = "/api/v1/channels.members"
-            Room.TYPE_PRIVATE -> restApiUrl = "/api/v1/groups.members"
+            Room.TYPE_GROUP -> restApiUrl = "/api/v1/groups.members"
             Room.TYPE_DIRECT_MESSAGE -> restApiUrl = "/api/v1/dm.members"
         }
         return restApiUrl

--- a/app/src/main/java/chat/rocket/android/layouthelper/chatroom/roomlist/ChannelRoomListHeader.java
+++ b/app/src/main/java/chat/rocket/android/layouthelper/chatroom/roomlist/ChannelRoomListHeader.java
@@ -23,14 +23,14 @@ public class ChannelRoomListHeader implements RoomListHeader {
 
   @Override
   public boolean owns(RoomSidebar roomSidebar) {
-    return roomSidebar.getType().equals(Room.TYPE_CHANNEL) || roomSidebar.getType().equals(Room.TYPE_PRIVATE);
+    return roomSidebar.getType().equals(Room.TYPE_CHANNEL) || roomSidebar.getType().equals(Room.TYPE_GROUP);
   }
 
   @Override
   public boolean shouldShow(@NonNull List<RoomSidebar> roomSidebarList) {
     for (RoomSidebar roomSidebar: roomSidebarList) {
       if ((roomSidebar.getType().equals(Room.TYPE_CHANNEL)
-              || roomSidebar.getType().equals(Room.TYPE_PRIVATE))
+              || roomSidebar.getType().equals(Room.TYPE_GROUP))
               && !roomSidebar.isAlert()
               && !roomSidebar.isFavorite()) {
         return true;

--- a/app/src/main/java/chat/rocket/android/layouthelper/chatroom/roomlist/RoomListItemViewHolder.java
+++ b/app/src/main/java/chat/rocket/android/layouthelper/chatroom/roomlist/RoomListItemViewHolder.java
@@ -2,6 +2,7 @@ package chat.rocket.android.layouthelper.chatroom.roomlist;
 
 import android.support.v7.widget.RecyclerView;
 
+import chat.rocket.android.helper.Logger;
 import chat.rocket.android.widget.internal.RoomListItemView;
 import chat.rocket.core.models.Room;
 import chat.rocket.core.models.RoomSidebar;
@@ -98,8 +99,10 @@ public class RoomListItemViewHolder extends RecyclerView.ViewHolder {
       case Room.TYPE_LIVECHAT:
         itemView.showLivechatChannelIcon();
         break;
-      default:
-        throw new AssertionError("Room type doesn't satisfies the method documentation. Room type is:" + roomType);
+      default: {
+        itemView.showPrivateChannelIcon();
+        Logger.report(new AssertionError("Room type doesn't satisfies the method documentation. Room type is:" + roomType));
+      }
     }
   }
 }

--- a/app/src/main/java/chat/rocket/android/layouthelper/chatroom/roomlist/RoomListItemViewHolder.java
+++ b/app/src/main/java/chat/rocket/android/layouthelper/chatroom/roomlist/RoomListItemViewHolder.java
@@ -93,7 +93,7 @@ public class RoomListItemViewHolder extends RecyclerView.ViewHolder {
       case Room.TYPE_CHANNEL:
         itemView.showPublicChannelIcon();
         break;
-      case Room.TYPE_PRIVATE:
+      case Room.TYPE_GROUP:
         itemView.showPrivateChannelIcon();
         break;
       case Room.TYPE_LIVECHAT:

--- a/app/src/test/kotlin/chat/rocket/android/api/rest/RestApiHelperTest.kt
+++ b/app/src/test/kotlin/chat/rocket/android/api/rest/RestApiHelperTest.kt
@@ -9,102 +9,102 @@ class RestApiHelperTest {
     @Test
     fun getEndpointUrlForMessagesTest() {
         assertEquals("https://demo.rocket.chat/api/v1/channels.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_CHANNEL, "demo.rocket.chat"))
-        assertEquals("https://demo.rocket.chat/api/v1/groups.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_PRIVATE, "demo.rocket.chat"))
+        assertEquals("https://demo.rocket.chat/api/v1/groups.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_GROUP, "demo.rocket.chat"))
         assertEquals("https://demo.rocket.chat/api/v1/dm.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_DIRECT_MESSAGE, "demo.rocket.chat"))
 
         assertEquals("https://demo.rocket.chat/api/v1/channels.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_CHANNEL, "https://demo.rocket.chat"))
-        assertEquals("https://demo.rocket.chat/api/v1/groups.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_PRIVATE, "https://demo.rocket.chat"))
+        assertEquals("https://demo.rocket.chat/api/v1/groups.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_GROUP, "https://demo.rocket.chat"))
         assertEquals("https://demo.rocket.chat/api/v1/dm.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_DIRECT_MESSAGE, "https://demo.rocket.chat"))
 
         assertEquals("https://demo.rocket.chat/api/v1/channels.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_CHANNEL, "http://demo.rocket.chat"))
-        assertEquals("https://demo.rocket.chat/api/v1/groups.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_PRIVATE, "http://demo.rocket.chat"))
+        assertEquals("https://demo.rocket.chat/api/v1/groups.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_GROUP, "http://demo.rocket.chat"))
         assertEquals("https://demo.rocket.chat/api/v1/dm.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_DIRECT_MESSAGE, "http://demo.rocket.chat"))
 
         assertEquals("https://www.demo.rocket.chat/api/v1/channels.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_CHANNEL, "www.demo.rocket.chat"))
-        assertEquals("https://www.demo.rocket.chat/api/v1/groups.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_PRIVATE, "www.demo.rocket.chat"))
+        assertEquals("https://www.demo.rocket.chat/api/v1/groups.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_GROUP, "www.demo.rocket.chat"))
         assertEquals("https://www.demo.rocket.chat/api/v1/dm.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_DIRECT_MESSAGE, "www.demo.rocket.chat"))
 
         assertEquals("https://www.demo.rocket.chat/api/v1/channels.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_CHANNEL, "https://www.demo.rocket.chat"))
-        assertEquals("https://www.demo.rocket.chat/api/v1/groups.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_PRIVATE, "https://www.demo.rocket.chat"))
+        assertEquals("https://www.demo.rocket.chat/api/v1/groups.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_GROUP, "https://www.demo.rocket.chat"))
         assertEquals("https://www.demo.rocket.chat/api/v1/dm.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_DIRECT_MESSAGE, "https://www.demo.rocket.chat"))
 
         assertEquals("https://www.demo.rocket.chat/api/v1/channels.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_CHANNEL, "http://www.demo.rocket.chat"))
-        assertEquals("https://www.demo.rocket.chat/api/v1/groups.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_PRIVATE, "http://www.demo.rocket.chat"))
+        assertEquals("https://www.demo.rocket.chat/api/v1/groups.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_GROUP, "http://www.demo.rocket.chat"))
         assertEquals("https://www.demo.rocket.chat/api/v1/dm.messages", RestApiHelper.getEndpointUrlForMessages(Room.TYPE_DIRECT_MESSAGE, "http://www.demo.rocket.chat"))
     }
 
     @Test
     fun getEndpointUrlForFileListTest() {
         assertEquals("https://demo.rocket.chat/api/v1/channels.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_CHANNEL, "demo.rocket.chat"))
-        assertEquals("https://demo.rocket.chat/api/v1/groups.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_PRIVATE, "demo.rocket.chat"))
+        assertEquals("https://demo.rocket.chat/api/v1/groups.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_GROUP, "demo.rocket.chat"))
         assertEquals("https://demo.rocket.chat/api/v1/dm.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_DIRECT_MESSAGE, "demo.rocket.chat"))
 
         assertEquals("https://demo.rocket.chat/api/v1/channels.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_CHANNEL, "https://demo.rocket.chat"))
-        assertEquals("https://demo.rocket.chat/api/v1/groups.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_PRIVATE, "https://demo.rocket.chat"))
+        assertEquals("https://demo.rocket.chat/api/v1/groups.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_GROUP, "https://demo.rocket.chat"))
         assertEquals("https://demo.rocket.chat/api/v1/dm.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_DIRECT_MESSAGE, "https://demo.rocket.chat"))
 
         assertEquals("https://demo.rocket.chat/api/v1/channels.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_CHANNEL, "http://demo.rocket.chat"))
-        assertEquals("https://demo.rocket.chat/api/v1/groups.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_PRIVATE, "http://demo.rocket.chat"))
+        assertEquals("https://demo.rocket.chat/api/v1/groups.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_GROUP, "http://demo.rocket.chat"))
         assertEquals("https://demo.rocket.chat/api/v1/dm.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_DIRECT_MESSAGE, "http://demo.rocket.chat"))
 
         assertEquals("https://www.demo.rocket.chat/api/v1/channels.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_CHANNEL, "www.demo.rocket.chat"))
-        assertEquals("https://www.demo.rocket.chat/api/v1/groups.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_PRIVATE, "www.demo.rocket.chat"))
+        assertEquals("https://www.demo.rocket.chat/api/v1/groups.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_GROUP, "www.demo.rocket.chat"))
         assertEquals("https://www.demo.rocket.chat/api/v1/dm.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_DIRECT_MESSAGE, "www.demo.rocket.chat"))
 
         assertEquals("https://www.demo.rocket.chat/api/v1/channels.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_CHANNEL, "https://www.demo.rocket.chat"))
-        assertEquals("https://www.demo.rocket.chat/api/v1/groups.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_PRIVATE, "https://www.demo.rocket.chat"))
+        assertEquals("https://www.demo.rocket.chat/api/v1/groups.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_GROUP, "https://www.demo.rocket.chat"))
         assertEquals("https://www.demo.rocket.chat/api/v1/dm.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_DIRECT_MESSAGE, "https://www.demo.rocket.chat"))
 
         assertEquals("https://www.demo.rocket.chat/api/v1/channels.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_CHANNEL, "http://www.demo.rocket.chat"))
-        assertEquals("https://www.demo.rocket.chat/api/v1/groups.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_PRIVATE, "http://www.demo.rocket.chat"))
+        assertEquals("https://www.demo.rocket.chat/api/v1/groups.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_GROUP, "http://www.demo.rocket.chat"))
         assertEquals("https://www.demo.rocket.chat/api/v1/dm.files", RestApiHelper.getEndpointUrlForFileList(Room.TYPE_DIRECT_MESSAGE, "http://www.demo.rocket.chat"))
     }
 
     @Test
     fun getEndpointUrlForMemberListTest() {
         assertEquals("https://demo.rocket.chat/api/v1/channels.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_CHANNEL, "demo.rocket.chat"))
-        assertEquals("https://demo.rocket.chat/api/v1/groups.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_PRIVATE, "demo.rocket.chat"))
+        assertEquals("https://demo.rocket.chat/api/v1/groups.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_GROUP, "demo.rocket.chat"))
         assertEquals("https://demo.rocket.chat/api/v1/dm.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_DIRECT_MESSAGE, "demo.rocket.chat"))
 
         assertEquals("https://demo.rocket.chat/api/v1/channels.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_CHANNEL, "https://demo.rocket.chat"))
-        assertEquals("https://demo.rocket.chat/api/v1/groups.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_PRIVATE, "https://demo.rocket.chat"))
+        assertEquals("https://demo.rocket.chat/api/v1/groups.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_GROUP, "https://demo.rocket.chat"))
         assertEquals("https://demo.rocket.chat/api/v1/dm.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_DIRECT_MESSAGE, "https://demo.rocket.chat"))
 
         assertEquals("https://demo.rocket.chat/api/v1/channels.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_CHANNEL, "http://demo.rocket.chat"))
-        assertEquals("https://demo.rocket.chat/api/v1/groups.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_PRIVATE, "http://demo.rocket.chat"))
+        assertEquals("https://demo.rocket.chat/api/v1/groups.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_GROUP, "http://demo.rocket.chat"))
         assertEquals("https://demo.rocket.chat/api/v1/dm.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_DIRECT_MESSAGE, "http://demo.rocket.chat"))
 
         assertEquals("https://www.demo.rocket.chat/api/v1/channels.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_CHANNEL, "www.demo.rocket.chat"))
-        assertEquals("https://www.demo.rocket.chat/api/v1/groups.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_PRIVATE, "www.demo.rocket.chat"))
+        assertEquals("https://www.demo.rocket.chat/api/v1/groups.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_GROUP, "www.demo.rocket.chat"))
         assertEquals("https://www.demo.rocket.chat/api/v1/dm.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_DIRECT_MESSAGE, "www.demo.rocket.chat"))
 
         assertEquals("https://www.demo.rocket.chat/api/v1/channels.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_CHANNEL, "https://www.demo.rocket.chat"))
-        assertEquals("https://www.demo.rocket.chat/api/v1/groups.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_PRIVATE, "https://www.demo.rocket.chat"))
+        assertEquals("https://www.demo.rocket.chat/api/v1/groups.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_GROUP, "https://www.demo.rocket.chat"))
         assertEquals("https://www.demo.rocket.chat/api/v1/dm.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_DIRECT_MESSAGE, "https://www.demo.rocket.chat"))
 
         assertEquals("https://www.demo.rocket.chat/api/v1/channels.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_CHANNEL, "http://www.demo.rocket.chat"))
-        assertEquals("https://www.demo.rocket.chat/api/v1/groups.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_PRIVATE, "http://www.demo.rocket.chat"))
+        assertEquals("https://www.demo.rocket.chat/api/v1/groups.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_GROUP, "http://www.demo.rocket.chat"))
         assertEquals("https://www.demo.rocket.chat/api/v1/dm.members", RestApiHelper.getEndpointUrlForMemberList(Room.TYPE_DIRECT_MESSAGE, "http://www.demo.rocket.chat"))
     }
 
     @Test
     fun getRestApiUrlForMessagesTest() {
         assertEquals("/api/v1/channels.messages", RestApiHelper.getRestApiUrlForMessages(Room.TYPE_CHANNEL))
-        assertEquals("/api/v1/groups.messages", RestApiHelper.getRestApiUrlForMessages(Room.TYPE_PRIVATE))
+        assertEquals("/api/v1/groups.messages", RestApiHelper.getRestApiUrlForMessages(Room.TYPE_GROUP))
         assertEquals("/api/v1/dm.messages", RestApiHelper.getRestApiUrlForMessages(Room.TYPE_DIRECT_MESSAGE))
     }
 
     @Test
     fun getRestApiUrlForFileListTest() {
         assertEquals("/api/v1/channels.files", RestApiHelper.getRestApiUrlForFileList(Room.TYPE_CHANNEL))
-        assertEquals("/api/v1/groups.files", RestApiHelper.getRestApiUrlForFileList(Room.TYPE_PRIVATE))
+        assertEquals("/api/v1/groups.files", RestApiHelper.getRestApiUrlForFileList(Room.TYPE_GROUP))
         assertEquals("/api/v1/dm.files", RestApiHelper.getRestApiUrlForFileList(Room.TYPE_DIRECT_MESSAGE))
     }
 
     @Test
     fun getRestApiUrlForMemberListTest() {
         assertEquals("/api/v1/channels.members", RestApiHelper.getRestApiUrlForMemberList(Room.TYPE_CHANNEL))
-        assertEquals("/api/v1/groups.members", RestApiHelper.getRestApiUrlForMemberList(Room.TYPE_PRIVATE))
+        assertEquals("/api/v1/groups.members", RestApiHelper.getRestApiUrlForMemberList(Room.TYPE_GROUP))
         assertEquals("/api/v1/dm.members", RestApiHelper.getRestApiUrlForMemberList(Room.TYPE_DIRECT_MESSAGE))
     }
 }

--- a/rocket-chat-core/src/main/java/chat/rocket/core/models/Room.java
+++ b/rocket-chat-core/src/main/java/chat/rocket/core/models/Room.java
@@ -6,7 +6,7 @@ import com.google.auto.value.AutoValue;
 public abstract class Room {
 
   public static final String TYPE_CHANNEL = "c";
-  public static final String TYPE_PRIVATE = "p";
+  public static final String TYPE_GROUP = "p";
   public static final String TYPE_DIRECT_MESSAGE = "d";
   public static final String TYPE_LIVECHAT = "l";
 
@@ -35,7 +35,7 @@ public abstract class Room {
   }
 
   public boolean isPrivate() {
-    return TYPE_PRIVATE.equals(getType());
+    return TYPE_GROUP.equals(getType());
   }
 
   public boolean isDirectMessage() {

--- a/rocket-chat-core/src/main/java/chat/rocket/core/models/RoomSidebar.kt
+++ b/rocket-chat-core/src/main/java/chat/rocket/core/models/RoomSidebar.kt
@@ -2,9 +2,10 @@ package chat.rocket.core.models
 
 class RoomSidebar {
     lateinit var id: String
-    lateinit var roomId: String
     lateinit var roomName: String
-    lateinit var type: String
+    lateinit var roomId: String
+    var type: String? = null
+        get() = RoomType.get(field) ?: Room.TYPE_GROUP
     var userStatus: String? = null
     var isAlert: Boolean = false
     var isFavorite: Boolean = false

--- a/rocket-chat-core/src/main/java/chat/rocket/core/models/RoomType.java
+++ b/rocket-chat-core/src/main/java/chat/rocket/core/models/RoomType.java
@@ -1,0 +1,26 @@
+package chat.rocket.core.models;
+
+import org.jetbrains.annotations.Nullable;
+
+public enum RoomType {
+    CHANNEL("c"),
+    GROUP("p"),
+    DIRECT_MESSAGE("d"),
+    LIVECHAT("l")
+    ;
+
+    private final String type;
+    RoomType(String type) {
+        this.type = type;
+    }
+
+    @Nullable
+    public static String get(@Nullable String type) {
+        for (RoomType roomType : RoomType.values()) {
+            if (roomType.type.equals(type)) {
+                return roomType.type;
+            }
+        }
+        return null;
+    }
+}

--- a/rocket-chat-core/src/main/java/chat/rocket/core/models/SpotlightRoom.java
+++ b/rocket-chat-core/src/main/java/chat/rocket/core/models/SpotlightRoom.java
@@ -16,7 +16,7 @@ public abstract class SpotlightRoom {
   }
 
   public boolean isPrivate() {
-    return Room.TYPE_PRIVATE.equals(getType());
+    return Room.TYPE_GROUP.equals(getType());
   }
 
   public boolean isDirectMessage() {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

Adds the fallback to group when getting room types other than the default ones.