### PR TITLE
Closes #342. Adds Play Store update check and update button to sideba…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -167,6 +167,7 @@ dependencies {
     compile 'com.jakewharton.timber:timber:4.5.1'
     compile 'com.github.matrixxun:MaterialBadgeTextView:c5a27e8243'
     compile 'com.github.chrisbanes:PhotoView:2.0.0'
+    compile 'com.github.javiersantos:AppUpdater:2.6.3'
     provided 'io.reactivex:rxjava:1.3.0'
     provided "com.github.akarnokd:rxjava2-interop:0.10.2"
     provided 'com.hadisatrio:Optional:v1.0.1'

--- a/app/src/main/java/chat/rocket/android/fragment/sidebar/SidebarMainContract.java
+++ b/app/src/main/java/chat/rocket/android/fragment/sidebar/SidebarMainContract.java
@@ -25,6 +25,11 @@ public interface SidebarMainContract {
     void show(User user);
 
     void onLogoutCleanUp();
+
+    void showUpdateAvailable();
+
+    void showNoUpdateAvailable();
+
   }
 
   interface Presenter extends BaseContract.Presenter<View> {

--- a/app/src/main/java/chat/rocket/android/fragment/sidebar/SidebarMainFragment.java
+++ b/app/src/main/java/chat/rocket/android/fragment/sidebar/SidebarMainFragment.java
@@ -2,6 +2,8 @@ package chat.rocket.android.fragment.sidebar;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -41,6 +43,9 @@ import chat.rocket.android.layouthelper.chatroom.roomlist.RoomListAdapter;
 import chat.rocket.android.layouthelper.chatroom.roomlist.RoomListHeader;
 import chat.rocket.android.layouthelper.chatroom.roomlist.UnreadRoomListHeader;
 import chat.rocket.android.renderer.UserRenderer;
+import chat.rocket.android.update.UpdateRepositoryImpl;
+import chat.rocket.android.widget.DownUpToggleView;
+import chat.rocket.core.interactors.CheckUpdateInteractor;
 import chat.rocket.core.interactors.RoomInteractor;
 import chat.rocket.core.interactors.SessionInteractor;
 import chat.rocket.core.models.RoomSidebar;
@@ -102,7 +107,8 @@ public class SidebarMainFragment extends AbstractFragment implements SidebarMain
         rocketChatCache,
         absoluteUrlHelper,
         new MethodCallHelper(getContext(), hostname),
-        new RealmSpotlightRepository(hostname)
+        new RealmSpotlightRepository(hostname),
+        new CheckUpdateInteractor(new UpdateRepositoryImpl(getContext()))
     );
   }
 
@@ -334,6 +340,24 @@ public class SidebarMainFragment extends AbstractFragment implements SidebarMain
         return null;
       });
     }
+  }
+
+  @Override
+  public void showUpdateAvailable() {
+    ((DownUpToggleView)rootView.findViewById(R.id.toggle_user_action)).showIndicator();
+    View button = rootView.findViewById(R.id.btn_update);
+    button.setVisibility(View.VISIBLE);
+    button.setOnClickListener(view -> {
+      Intent intent = new Intent(Intent.ACTION_VIEW);
+      intent.setData(Uri.parse("market://details?id=com.konecty.rocket.chat"));
+      startActivity(intent);
+    });
+  }
+
+  @Override
+  public void showNoUpdateAvailable() {
+    ((DownUpToggleView)rootView.findViewById(R.id.toggle_user_action)).hideIndicator();
+    rootView.findViewById(R.id.btn_update).setVisibility(View.GONE);
   }
 
   private void setupLogoutButton() {

--- a/app/src/main/java/chat/rocket/android/update/UpdateRepositoryImpl.kt
+++ b/app/src/main/java/chat/rocket/android/update/UpdateRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package chat.rocket.android.update
+
+import android.content.Context
+import chat.rocket.core.repositories.UpdateRepository
+import com.github.javiersantos.appupdater.AppUpdaterUtils
+import com.github.javiersantos.appupdater.enums.AppUpdaterError
+import com.github.javiersantos.appupdater.enums.UpdateFrom
+import com.github.javiersantos.appupdater.objects.Update
+import io.reactivex.Observable
+import io.reactivex.subjects.PublishSubject
+
+class UpdateRepositoryImpl(context: Context) : UpdateRepository {
+
+    private val mPublishSubject: PublishSubject<Boolean> = PublishSubject.create()
+    private val mAppUpdaterUtils: AppUpdaterUtils = AppUpdaterUtils(context.applicationContext)
+            .setUpdateFrom(UpdateFrom.GOOGLE_PLAY)
+            .withListener(object : AppUpdaterUtils.UpdateListener {
+                override fun onSuccess(update: Update, isUpdateAvailable: Boolean) = mPublishSubject.onNext(isUpdateAvailable)
+
+                override fun onFailed(error: AppUpdaterError) = mPublishSubject.onNext(false)
+            })
+
+    override fun getUpdateAvailable(): Observable<Boolean> = mPublishSubject
+
+    override fun refresh() {
+        mAppUpdaterUtils.start()
+    }
+
+}

--- a/app/src/main/res/layout/fragment_sidebar_main.xml
+++ b/app/src/main/res/layout/fragment_sidebar_main.xml
@@ -181,6 +181,33 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
+            <LinearLayout
+                android:id="@+id/btn_update"
+                style="@style/sidebar_list_item"
+                android:orientation="horizontal"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <FrameLayout
+                    android:layout_width="48dp"
+                    android:layout_height="match_parent">
+
+                    <io.github.yusukeiwaki.android.widget.FontAwesomeTextView
+                        android:layout_width="16dp"
+                        android:layout_height="16dp"
+                        android:layout_gravity="center"
+                        android:gravity="center"
+                        android:text="@string/fa_wrench"
+                        android:textSize="14dp"/>
+                </FrameLayout>
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/fragment_sidebar_main_update_title"
+                    android:textAppearance="?attr/textAppearanceListItemSmall"/>
+            </LinearLayout>
+
             <TextView
                 android:id="@+id/version_info"
                 android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="user_status_busy">Busy</string>
     <string name="user_status_invisible">Invisible</string>
     <string name="fragment_sidebar_main_logout_title">Logout</string>
+    <string name="fragment_sidebar_main_update_title">Update RocketChat</string>
     <string name="dialog_add_channel_name">name</string>
     <string name="dialog_add_channel_private">private</string>
     <string name="dialog_add_channel_read_only">read only</string>

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ allprojects {
         maven { url 'https://github.com/lijingle1/stetho-realm/raw/master/maven-repo' }
         maven { url 'http://dl.bintray.com/amulyakhare/maven' } //for TextDrawable.
         maven { url "https://clojars.org/repo/" } //for icepick.
-        maven { url 'https://jitpack.io' } //for widget-fontawesome.
+        maven { url 'https://jitpack.io' } //for widget-fontawesome & AppUpdater.
         maven { url "https://maven.google.com" } // for Support Library.
     }
 }

--- a/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/DownUpToggleView.java
+++ b/rocket-chat-android-widgets/src/main/java/chat/rocket/android/widget/DownUpToggleView.java
@@ -1,10 +1,19 @@
 package chat.rocket.android.widget;
 
 import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.support.v4.content.res.ResourcesCompat;
 import android.support.v7.widget.AppCompatCheckBox;
 import android.util.AttributeSet;
 
 public class DownUpToggleView extends AppCompatCheckBox {
+
+  public static final int RADIUS = 14;
+
+  private boolean mShowIndicator;
+  private Paint mPaint;
+  private int mCx;
 
   public DownUpToggleView(Context context) {
     super(context);
@@ -23,5 +32,35 @@ public class DownUpToggleView extends AppCompatCheckBox {
 
   private void initialize(Context context, AttributeSet attrs) {
     setButtonDrawable(R.drawable.down_up_toggle);
+    mPaint = new Paint();
+    mPaint.setColor(ResourcesCompat.getColor(getResources(), R.color.color_accent, null));
+    mPaint.setStyle(Paint.Style.FILL);
+  }
+
+  @Override
+  protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+    super.onLayout(changed, left, top, right, bottom);
+
+    // Pre-calculate cx so that when drawer is slid,
+    // then current value of `getWidth` is not used
+    mCx = getWidth() - RADIUS;
+  }
+
+  @Override
+  protected void onDraw(Canvas canvas) {
+    super.onDraw(canvas);
+    if (mShowIndicator) {
+      canvas.drawCircle(mCx, RADIUS, RADIUS, mPaint);
+    }
+  }
+
+  public void showIndicator() {
+    mShowIndicator = true;
+    invalidate();
+  }
+
+  public void hideIndicator() {
+    mShowIndicator = false;
+    invalidate();
   }
 }

--- a/rocket-chat-core/src/main/java/chat/rocket/core/interactors/CheckUpdateInteractor.kt
+++ b/rocket-chat-core/src/main/java/chat/rocket/core/interactors/CheckUpdateInteractor.kt
@@ -1,0 +1,10 @@
+package chat.rocket.core.interactors
+
+import chat.rocket.core.repositories.UpdateRepository
+import io.reactivex.Observable
+
+class CheckUpdateInteractor(private val repository: UpdateRepository) {
+
+    fun check(): Observable<Boolean> = repository.getUpdateAvailable().doOnSubscribe { repository.refresh() }
+
+}

--- a/rocket-chat-core/src/main/java/chat/rocket/core/repositories/UpdateRepository.kt
+++ b/rocket-chat-core/src/main/java/chat/rocket/core/repositories/UpdateRepository.kt
@@ -1,0 +1,11 @@
+package chat.rocket.core.repositories
+
+import io.reactivex.Observable
+
+interface UpdateRepository {
+
+    fun getUpdateAvailable(): Observable<Boolean>
+
+    fun refresh()
+
+}


### PR DESCRIPTION
…r with link to Play Store listing. Adds simple notification to toggle.

@RocketChat/android

Closes #342 

## Description
As per 342, uses AppUpdater library to check Play Store version name and adds menu item if update available. Also adds blue notification dot to indicate to user.  

## Implementation
`SidebarMainPresenter` subscribes to `CheckUpdateInteractor` `Observable`. The interactor upon subscription forces a re-fresh of the `UpdateRepository` and will return a `Boolean` as to whether the Play Store version is greater than the current (as per library logic). In the case of an error, it will assume there is no update. Based on the subscribed value, the view will either be invoked to show or hide the "Update RocketChat" menu item (hidden by default) and draw a `color_accent` circle to the `DownUpToggleView` `Canvas`. Implementation can also handle the repository checking at an interval - currently it will only check when a view is bound to the sidebar presenter. 

## Screenshots
![screenshot_20171017-225049](https://user-images.githubusercontent.com/3862718/31691955-b8bb52c6-b38f-11e7-881f-526ac9bac170.png)
![screenshot_20171017-225055](https://user-images.githubusercontent.com/3862718/31691956-b8d0a892-b38f-11e7-88c5-be53d63457ca.png)
