### PR TITLE
[IMPROVEMENT] Changed 'hostname' to 'Server'

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,7 +47,7 @@
     <string name="username">\@%s</string>
     <string name="dialog_user_registration_password">Password</string>
     <string name="fragment_home_welcome_message">Welcome to Rocket.Chat.Android\nSelect a channel from the drawer.</string>
-    <string name="fragment_input_hostname_hostname">Hostname</string>
+    <string name="fragment_input_hostname_hostname">Server</string>
     <string name="fragment_input_hostname_server_hint">open.rocket.chat</string>
     <string name="fragment_input_hostname_connect">CONNECT</string>
     <string name="fragment_login_username_or_email">Username or email</string>


### PR DESCRIPTION
The word 'Server' is used elsewhere on RocketChat, and 'hostname' isn't intuitive for the non-technical users, whereas most can wrap their head around 'server'. Had people using their username as a hostname, that kind of silliness.