### PR TITLE
[BUG] Resolves incorrect context issue in login activity

### DIFF
--- a/app/src/main/java/chat/rocket/android/activity/LoginActivity.java
+++ b/app/src/main/java/chat/rocket/android/activity/LoginActivity.java
@@ -1,6 +1,5 @@
 package chat.rocket.android.activity;
 
-import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -100,8 +99,7 @@ public class LoginActivity extends AbstractFragmentActivity implements LoginCont
         } else if (BackStackHelper.FRAGMENT_TAG.equals("login")) {
             LoginFragment loginFragment = (LoginFragment) getSupportFragmentManager()
                     .findFragmentById(getLayoutContainerForFragment());
-            Context loginActivityContext = this;
-            loginFragment.goBack(loginActivityContext);
+            loginFragment.goBack();
         }
         return true;
     }

--- a/app/src/main/java/chat/rocket/android/activity/LoginActivity.java
+++ b/app/src/main/java/chat/rocket/android/activity/LoginActivity.java
@@ -9,6 +9,7 @@ import android.support.v4.app.Fragment;
 import chat.rocket.android.R;
 import chat.rocket.android.fragment.server_config.LoginFragment;
 import chat.rocket.android.fragment.server_config.RetryLoginFragment;
+import chat.rocket.android.helper.BackStackHelper;
 import chat.rocket.android.service.ConnectivityManager;
 import chat.rocket.core.interactors.SessionInteractor;
 import chat.rocket.persistence.realm.repositories.RealmSessionRepository;
@@ -93,10 +94,15 @@ public class LoginActivity extends AbstractFragmentActivity implements LoginCont
 
     @Override
     protected boolean onBackPress() {
-        LoginFragment loginFragment = (LoginFragment) getSupportFragmentManager()
-                .findFragmentById(getLayoutContainerForFragment());
-        Context loginActivityContext = this;
-        loginFragment.goBack(loginActivityContext);
+        if (BackStackHelper.FRAGMENT_TAG.equals("internal")) {
+            super.onBackPress();
+            BackStackHelper.FRAGMENT_TAG = "login";
+        } else if (BackStackHelper.FRAGMENT_TAG.equals("login")) {
+            LoginFragment loginFragment = (LoginFragment) getSupportFragmentManager()
+                    .findFragmentById(getLayoutContainerForFragment());
+            Context loginActivityContext = this;
+            loginFragment.goBack(loginActivityContext);
+        }
         return true;
     }
 }

--- a/app/src/main/java/chat/rocket/android/activity/LoginActivity.java
+++ b/app/src/main/java/chat/rocket/android/activity/LoginActivity.java
@@ -1,5 +1,6 @@
 package chat.rocket.android.activity;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -94,7 +95,8 @@ public class LoginActivity extends AbstractFragmentActivity implements LoginCont
     protected boolean onBackPress() {
         LoginFragment loginFragment = (LoginFragment) getSupportFragmentManager()
                 .findFragmentById(getLayoutContainerForFragment());
-        loginFragment.goBack();
+        Context loginActivityContext = this;
+        loginFragment.goBack(loginActivityContext);
         return true;
     }
 }

--- a/app/src/main/java/chat/rocket/android/fragment/server_config/AbstractServerConfigFragment.java
+++ b/app/src/main/java/chat/rocket/android/fragment/server_config/AbstractServerConfigFragment.java
@@ -6,39 +6,41 @@ import android.support.v4.app.Fragment;
 
 import chat.rocket.android.R;
 import chat.rocket.android.fragment.AbstractFragment;
+import chat.rocket.android.helper.BackStackHelper;
 import chat.rocket.android.helper.TextUtils;
 
 public abstract class AbstractServerConfigFragment extends AbstractFragment {
-  public static final String KEY_HOSTNAME = "hostname";
+    public static final String KEY_HOSTNAME = "hostname";
 
-  protected String hostname;
+    protected String hostname;
 
-  @Override
-  public void onCreate(@Nullable Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
 
-    Bundle args = getArguments();
-    if (args == null) {
-      finish();
-      return;
+        Bundle args = getArguments();
+        if (args == null) {
+            finish();
+            return;
+        }
+
+        hostname = args.getString(KEY_HOSTNAME);
+        if (TextUtils.isEmpty(hostname)) {
+            finish();
+        }
     }
 
-    hostname = args.getString(KEY_HOSTNAME);
-    if (TextUtils.isEmpty(hostname)) {
-      finish();
+    protected void showFragment(Fragment fragment) {
+        getFragmentManager().beginTransaction()
+                .add(R.id.content, fragment)
+                .commit();
+    }   
+
+    protected void showFragmentWithBackStack(Fragment fragment) {
+        BackStackHelper.FRAGMENT_TAG = "internal";
+        getFragmentManager().beginTransaction()
+                .add(R.id.content, fragment)
+                .addToBackStack(null)
+                .commit();
     }
-  }
-
-  protected void showFragment(Fragment fragment) {
-    getFragmentManager().beginTransaction()
-        .add(R.id.content, fragment)
-        .commit();
-  }
-
-  protected void showFragmentWithBackStack(Fragment fragment) {
-    getFragmentManager().beginTransaction()
-        .add(R.id.content, fragment)
-        .addToBackStack(null)
-        .commit();
-  }
 }

--- a/app/src/main/java/chat/rocket/android/fragment/server_config/LoginContract.java
+++ b/app/src/main/java/chat/rocket/android/fragment/server_config/LoginContract.java
@@ -26,7 +26,7 @@ public interface LoginContract {
 
         void showTwoStepAuth();
 
-        void goBack(Context ctx);
+        void goBack();
     }
 
     interface Presenter extends BaseContract.Presenter<View> {

--- a/app/src/main/java/chat/rocket/android/fragment/server_config/LoginContract.java
+++ b/app/src/main/java/chat/rocket/android/fragment/server_config/LoginContract.java
@@ -1,5 +1,8 @@
 package chat.rocket.android.fragment.server_config;
 
+
+import android.content.Context;
+
 import java.util.List;
 
 import chat.rocket.android.shared.BaseContract;
@@ -19,13 +22,13 @@ public interface LoginContract {
 
         void showTwoStepAuth();
 
-        void goBack();
+        void goBack(Context ctx);
     }
 
     interface Presenter extends BaseContract.Presenter<View> {
 
         void login(String username, String password);
 
-        void goBack();
+        void goBack(Context ctx);
     }
 }

--- a/app/src/main/java/chat/rocket/android/fragment/server_config/LoginFragment.kt
+++ b/app/src/main/java/chat/rocket/android/fragment/server_config/LoginFragment.kt
@@ -1,6 +1,5 @@
 package chat.rocket.android.fragment.server_config
 
-import android.content.Context
 import android.os.Bundle
 import android.support.constraint.ConstraintLayout
 import android.support.design.widget.Snackbar
@@ -161,8 +160,9 @@ class LoginFragment : AbstractServerConfigFragment(), LoginContract.View {
         presenter.release()
         super.onPause()
     }
-    override fun goBack(ctx: Context?) {
-        presenter.goBack(ctx)
+    
+    override fun goBack() {
+        presenter.goBack(context)
     }
 
 }

--- a/app/src/main/java/chat/rocket/android/fragment/server_config/LoginFragment.kt
+++ b/app/src/main/java/chat/rocket/android/fragment/server_config/LoginFragment.kt
@@ -1,5 +1,6 @@
 package chat.rocket.android.fragment.server_config
 
+import android.content.Context
 import android.os.Bundle
 import android.support.constraint.ConstraintLayout
 import android.support.design.widget.Snackbar
@@ -126,8 +127,8 @@ class LoginFragment : AbstractServerConfigFragment(), LoginContract.View {
         presenter.release()
         super.onPause()
     }
-
-    override fun goBack() {
-        presenter.goBack()
+    override fun goBack(ctx: Context?) {
+        presenter.goBack(ctx)
     }
+
 }

--- a/app/src/main/java/chat/rocket/android/fragment/server_config/LoginPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/fragment/server_config/LoginPresenter.kt
@@ -33,7 +33,7 @@ class LoginPresenter(private val loginServiceConfigurationRepository: LoginServi
     }
 
 
-    override fun goBack(ctx : Context?) {
+    override fun goBack(ctx: Context?) {
         val context = RocketChatApplication.getInstance()
         val hostname = RocketChatCache.getSelectedServerHostname()
         hostname?.let {

--- a/app/src/main/java/chat/rocket/android/fragment/server_config/LoginPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/fragment/server_config/LoginPresenter.kt
@@ -1,5 +1,6 @@
 package chat.rocket.android.fragment.server_config
 
+import android.content.Context
 import bolts.Continuation
 import bolts.Task
 import chat.rocket.android.BackgroundLooper
@@ -31,7 +32,7 @@ class LoginPresenter(private val loginServiceConfigurationRepository: LoginServi
         getLoginServices()
     }
 
-    override fun goBack() {
+    override fun goBack(ctx : Context?) {
         val context = RocketChatApplication.getInstance()
         val hostname = RocketChatCache.getSelectedServerHostname()
         hostname?.let {
@@ -39,7 +40,7 @@ class LoginPresenter(private val loginServiceConfigurationRepository: LoginServi
             RocketChatCache.clearSelectedHostnameReferences()
 
         }
-        LaunchUtil.showMainActivity(context)
+        LaunchUtil.showMainActivity(ctx)
     }
 
     override fun login(username: String, password: String) {

--- a/app/src/main/java/chat/rocket/android/helper/BackStackHelper.java
+++ b/app/src/main/java/chat/rocket/android/helper/BackStackHelper.java
@@ -1,0 +1,9 @@
+package chat.rocket.android.helper;
+
+/**
+ * Created by whocares on 28/12/17.
+ */
+
+public class BackStackHelper {
+    public static String FRAGMENT_TAG = "login";
+}

--- a/app/src/main/java/chat/rocket/android/helper/BackStackHelper.java
+++ b/app/src/main/java/chat/rocket/android/helper/BackStackHelper.java
@@ -1,8 +1,5 @@
 package chat.rocket.android.helper;
 
-/**
- * Created by whocares on 28/12/17.
- */
 
 public class BackStackHelper {
     public static String FRAGMENT_TAG = "login";


### PR DESCRIPTION
@RocketChat/android

Closes #656 and #648 

It looked like an incorrect context was given to start add server url activity from login activity when back button is pressed. I fixed this bug by changing the context from that of the application to that of the LoginActivity.

See the context given here is the application's context.
https://github.com/RocketChat/Rocket.Chat.Android/blob/6f80a3c48e08b17ac6d8c088f394d45459800d89/app/src/main/java/chat/rocket/android/fragment/server_config/LoginPresenter.kt#L34-L43
@leonardoaramaki ^^