### PR TITLE
[TYPO] Fixes typo in pinned messages fragment

### DIFF
--- a/app/src/main/java/chat/rocket/android/activity/MainActivity.java
+++ b/app/src/main/java/chat/rocket/android/activity/MainActivity.java
@@ -94,7 +94,7 @@ public class MainActivity extends AbstractAuthedActivity implements MainContract
         } else {
             connectivityManager.keepAliveServer();
             presenter.bindView(this);
-            presenter.loadSignedInServers(hostname);
+            //presenter.loadSignedInServers(hostname);
             roomId = RocketChatCache.INSTANCE.getSelectedRoomId();
         }
     }

--- a/app/src/main/java/chat/rocket/android/activity/MainActivity.java
+++ b/app/src/main/java/chat/rocket/android/activity/MainActivity.java
@@ -94,7 +94,7 @@ public class MainActivity extends AbstractAuthedActivity implements MainContract
         } else {
             connectivityManager.keepAliveServer();
             presenter.bindView(this);
-            //presenter.loadSignedInServers(hostname);
+            presenter.loadSignedInServers(hostname);
             roomId = RocketChatCache.INSTANCE.getSelectedRoomId();
         }
     }

--- a/app/src/main/java/chat/rocket/android/fragment/chatroom/list/RoomListPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/fragment/chatroom/list/RoomListPresenter.kt
@@ -23,13 +23,14 @@ import java.sql.Timestamp
  * Created by Filipe de Lima Brito (filipedelimabrito@gmail.com) on 9/22/17.
  */
 class RoomListPresenter(val context: Context, val view: RoomListContract.View) : RoomListContract.Presenter {
-
+    private lateinit var TAG: String
     override fun requestPinnedMessages(roomId: String,
                                        roomType: String,
                                        hostname: String,
                                        token: String,
                                        userId: String,
                                        offset: Int) {
+        TAG = "pinned"
         view.showWaitingView(true)
         OkHttpHelper.getClient()
                 .newCall(RestApiHelper.getRequestForPinnedMessages(roomId,
@@ -53,7 +54,7 @@ class RoomListPresenter(val context: Context, val view: RoomListContract.View) :
                         if (response.isSuccessful) {
                             val result = response.body()?.string()
                             if (result != null) {
-                                handleMessagesJson(result, true)
+                                handleMessagesJson(result, true, TAG)
                             }
                         } else {
                             showErrorMessage(response.message())
@@ -68,6 +69,7 @@ class RoomListPresenter(val context: Context, val view: RoomListContract.View) :
                                          token: String,
                                          userId: String,
                                          offset: Int) {
+        TAG = "favorite"
         view.showWaitingView(true)
         OkHttpHelper.getClient()
                 .newCall(RestApiHelper.getRequestForFavoriteMessages(roomId,
@@ -91,7 +93,7 @@ class RoomListPresenter(val context: Context, val view: RoomListContract.View) :
                         if (response.isSuccessful) {
                             val result = response.body()?.string()
                             if (result != null) {
-                                handleMessagesJson(result, false)
+                                handleMessagesJson(result, false, TAG)
                             }
                         } else {
                             showErrorMessage(response.message())
@@ -180,7 +182,7 @@ class RoomListPresenter(val context: Context, val view: RoomListContract.View) :
         OkHttpHelper.getClient().dispatcher().cancelAll()
     }
 
-    private fun handleMessagesJson(json: String, isPinnedMessage: Boolean) {
+    private fun handleMessagesJson(json: String, isPinnedMessage: Boolean, TAG: String) {
         try {
             val jSONObject = JSONObject(json)
             val messagesJSONArray = jSONObject.getJSONArray("messages")
@@ -204,7 +206,10 @@ class RoomListPresenter(val context: Context, val view: RoomListContract.View) :
             }
 
             if (dataSet.isEmpty() && !hasItem) {
-                showEmptyViewMessage(context.getString(R.string.fragment_room_list_no_favorite_message_to_show))
+                if (TAG.equals("favorite"))
+                    showEmptyViewMessage(context.getString(R.string.fragment_room_list_no_favorite_message_to_show))
+                else if (TAG.equals("pinned"))
+                    showEmptyViewMessage(context.getString(R.string.fragment_room_list_no_pinned_message_to_show))
             } else {
                 if (dataSet.isNotEmpty()) {
                     hasItem = true

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,8 +18,8 @@
     <string name="fragment_room_list_file_list_title">File list (%s)</string>
     <string name="fragment_room_list_member_list_title">Member list (%s)</string>
     <string name="fragment_room_list_could_not_load_your_request">Could not load your request.\n%s.</string>
-    <string name="fragment_room_list_no_pinned_message_to_show">No pinned message to show</string>
-    <string name="fragment_room_list_no_favorite_message_to_show">No favorite message to show</string>
+    <string name="fragment_room_list_no_pinned_message_to_show">No pinned messages to show</string>
+    <string name="fragment_room_list_no_favorite_message_to_show">No favorite messages to show</string>
     <string name="fragment_room_list_no_file_list_to_show">No file list to show</string>
     <string name="fragment_room_list_no_member_list_to_show">No member list to show</string>
 


### PR DESCRIPTION
@RocketChat/android

Closes #669 

The cause of this error was that the same message was being shown for both pinned messages and favourite messages as there was no distinction between them. This pull request adds a tag to distinguish between the two cases.