### PR TITLE
[FIX] refactor: Update build-sdk.sh

### DIFF
--- a/app/build-sdk.sh
+++ b/app/build-sdk.sh
@@ -1,47 +1,48 @@
 #!/bin/bash
 
-CURRENT_DIR=`pwd`
+CURRENT_DIR=$(pwd)
 # The SDK dir should be 2 directories up in the tree, so we use dirname 2 times
 # to get the common parent dir of the SDK and the app
-GIT=`which git`
-tmp=`dirname $CURRENT_DIR`
-tmp=`dirname $tmp`
+GIT=$(which git)
+cd ../..
+tmp=$(pwd)
 SDK_DIR="$tmp/Rocket.Chat.Kotlin.SDK"
+cd "${CURRENT_DIR}"
 
 echo "CURRENT DIR: $CURRENT_DIR"
 echo "SDK DIR: $SDK_DIR"
 
-# check if there are changes not commited
+# check if there are changes not committed
 function git_stat {
-	local  __resultvar=$1
-	cd $SDK_DIR && $GIT diff --shortstat --exit-code
-	eval $__resultvar="'$?'"
+	local  resultVar=$1
+	cd "${SDK_DIR}" && "${GIT}" diff --shortstat --exit-code
+	eval ${resultVar}="'$?'"
 }
 
-# check for changes already on the index not commited
+# check for changes already on the index not committed
 function git_stat_cached {
-	local  __resultvar=$1
-	cd $SDK_DIR && $GIT diff --cached --shortstat --exit-code
-	eval $__resultvar="'$?'"
+	local  resultVar=$1
+	cd "${SDK_DIR}" && "${GIT}" diff --cached --shortstat --exit-code
+	eval ${resultVar}="'$?'"
 }
 
-# get the SHA of the lastest commit
+# get the SHA of the latest commit
 function git_sha {
-	temp_sha=`cd $SDK_DIR && $GIT rev-parse --short HEAD`
+	temp_sha=$(cd "${SDK_DIR}" && "${GIT}" rev-parse --short HEAD)
 	echo "$temp_sha"
 }
 
 function git_app_branch {
-	temp_branch=`cd $CURRENT_DIR && $GIT rev-parse --abbrev-ref HEAD`
+	temp_branch=$(cd "${CURRENT_DIR}" && "${GIT}" rev-parse --abbrev-ref HEAD)
 	echo "$temp_branch"
 }
 
-# check if the tree is dirty (has modifications not commited yet)
+# check if the tree is dirty (has modifications not committed yet)
 function check_git_dirty {
 	git_stat stat
 	git_stat_cached cached
 
-	if [ $stat -eq 0 ] && [ $cached -eq 0 ]; then
+	if [ ${stat} -eq 0 ] && [ ${cached} -eq 0 ]; then
 		echo "not dirty"
 		return 1
 	else
@@ -52,11 +53,11 @@ function check_git_dirty {
 
 # check if the saved last commit is the same as the latest SHA in the tree
 function check_last_commit {
-	if [ ! -f $SDK_DIR/.last_commit_hash ]; then
+	if [ ! -f ${SDK_DIR}/.last_commit_hash ]; then
 		echo "last_commit_hash not found"
 		return 0
 	fi
-	saved_hash=`cat $SDK_DIR/.last_commit_hash`
+	saved_hash=$(cat "${SDK_DIR}"/.last_commit_hash)
 	last_hash=$(git_sha)
 	#`cd $SDK_DIR && git rev-parse --short HEAD`
 	if [ "$saved_hash" == "$last_hash" ]; then
@@ -70,7 +71,7 @@ function check_last_commit {
 
 function checkout_matching_branch {
 	app_branch=$(git_app_branch)
-	cd $SDK_DIR && $GIT checkout $app_branch 1>/dev/null 2>/dev/null
+	cd "${SDK_DIR}" && "${GIT}" checkout "${app_branch}" 1>/dev/null 2>/dev/null
 }
 
 checkout_matching_branch
@@ -82,20 +83,20 @@ fi
 echo "CURRENT SHA: $SHA"
 
 # if the tree is not dirty, there is no new commit and the .jars are still there, just skip the build
-if ! check_git_dirty && ! check_last_commit && [ -f $CURRENT_DIR/libs/common-$SHA.jar ] && [ -f $CURRENT_DIR/libs/core-$SHA.jar ]; then
+if ! check_git_dirty && ! check_last_commit && [ -f "${CURRENT_DIR}"/libs/common-"${SHA}".jar ] && [ -f "${CURRENT_DIR}"/libs/core-"${SHA}".jar ]; then
 	echo "NO BUILD NEEDED"
 	exit 0
 fi
 
-cd $SDK_DIR && ./gradlew common:assemble && cd $CURRENT_DIR
-cd $SDK_DIR && ./gradlew core:assemble && cd $CURRENT_DIR
+cd "${SDK_DIR}" && ./gradlew common:assemble && cd "${CURRENT_DIR}"
+cd "${SDK_DIR}" && ./gradlew core:assemble && cd "${CURRENT_DIR}"
 
-rm $CURRENT_DIR/libs/common* $CURRENT_DIR/libs/core*
+rm "${CURRENT_DIR}"/libs/common* "${CURRENT_DIR}"/libs/core*
 
-mkdir -p $CURRENT_DIR/libs/
-cp -v $SDK_DIR/common/build/libs/common-0.1-SNAPSHOT.jar $CURRENT_DIR/libs/common-$SHA.jar
-cp -v $SDK_DIR/core/build/libs/core-0.1-SNAPSHOT.jar $CURRENT_DIR/libs/core-$SHA.jar
+mkdir -p "${CURRENT_DIR}"/libs/
+cp -v "${SDK_DIR}"/common/build/libs/common-0.1-SNAPSHOT.jar "${CURRENT_DIR}"/libs/common-"${SHA}".jar
+cp -v "${SDK_DIR}"/core/build/libs/core-0.1-SNAPSHOT.jar "${CURRENT_DIR}"/libs/core-"${SHA}".jar
 
-echo "$SHA" > $SDK_DIR/.last_commit_hash
+echo "$SHA" > "${SDK_DIR}"/.last_commit_hash
 
 exit 0

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,7 +126,11 @@ kotlin {
 // FIXME - build and install the sdk into the app/libs directory
 // We were having some issues with the kapt generated files from the sdk when importing as a module
 task compileSdk(type:Exec) {
-    commandLine './build-sdk.sh'
+    if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
+        commandLine 'cmd', '/c', 'build-sdk.sh'
+    } else {
+        commandLine './build-sdk.sh'
+    }
 }
 preBuild.dependsOn compileSdk
 


### PR DESCRIPTION
@RocketChat/android

Closes #773 

**Changes**
- Updated build-sdk.sh file

**log after changes**
```
CURRENT DIR: /home/shell/Git Projects/Rocket.Chat.Android/app
SDK DIR: /home/shell/Git Projects/Rocket.Chat.Kotlin.SDK
CURRENT SHA: 99b4ce6
 1 file changed, 1 insertion(+), 1 deletion(-)
is dirty

BUILD SUCCESSFUL in 0s
5 actionable tasks: 5 up-to-date

BUILD SUCCESSFUL in 0s
10 actionable tasks: 10 up-to-date
'/home/shell/Git Projects/Rocket.Chat.Kotlin.SDK/common/build/libs/common-0.1-SNAPSHOT.jar' -> '/home/shell/Git Projects/Rocket.Chat.Android/app/libs/common-99b4ce6.jar'
'/home/shell/Git Projects/Rocket.Chat.Kotlin.SDK/core/build/libs/core-0.1-SNAPSHOT.jar' -> '/home/shell/Git Projects/Rocket.Chat.Android/app/libs/core-99b4ce6.jar'
```