### PR TITLE
[NEW][FIX] Prevents losing all entered text when a new message arrives on the chat

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomPresenter.kt
@@ -39,7 +39,6 @@ class ChatRoomPresenter @Inject constructor(private val view: ChatRoomView,
     private val client = factory.create(serverInteractor.get()!!)
     private var subId: String? = null
     private var settings: Map<String, Value<Any>> = getSettingsInteractor.get(serverInteractor.get()!!)!!
-
     private val stateChannel = Channel<State>()
 
     fun loadMessages(chatRoomId: String, chatRoomType: String, offset: Long = 0) {
@@ -72,23 +71,23 @@ class ChatRoomPresenter @Inject constructor(private val view: ChatRoomView,
 
     fun sendMessage(chatRoomId: String, text: String, messageId: String?) {
         launchUI(strategy) {
-            view.disableMessageInput()
+            view.disableSendMessageButton()
             try {
+                // ignore message for now, will receive it on the stream
                 val message = if (messageId == null) {
                     client.sendMessage(chatRoomId, text)
                 } else {
                     client.updateMessage(chatRoomId, messageId, text)
                 }
-                // ignore message for now, will receive it on the stream
-                view.enableMessageInput(clear = true)
+                view.clearMessageComposition()
             } catch (ex: Exception) {
-                ex.printStackTrace()
                 ex.message?.let {
                     view.showMessage(it)
                 }.ifNull {
                     view.showGenericErrorMessage()
                 }
-                view.enableMessageInput()
+            } finally {
+                view.enableSendMessageButton()
             }
         }
     }

--- a/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomView.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomView.kt
@@ -75,7 +75,19 @@ interface ChatRoomView : LoadingView, MessageView {
      */
     fun showEditingAction(roomId: String, messageId: String, text: String)
 
-    fun disableMessageInput()
+    /**
+     * Disabling the send message button avoids the user tap this button multiple
+     * times to send a same message.
+     */
+    fun disableSendMessageButton()
 
-    fun enableMessageInput(clear: Boolean = false)
+    /**
+     * Enables the send message button.
+     */
+    fun enableSendMessageButton()
+
+    /**
+     * Clears the message composition.
+     */
+    fun clearMessageComposition()
 }

--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
@@ -255,28 +255,13 @@ class ChatRoomFragment : Fragment(), ChatRoomView {
             text_room_is_read_only.setVisible(true)
             input_container.setVisible(false)
         } else {
-            var playAnimation = true
-            text_message.asObservable(0)
-                .subscribe({ t ->
-                    if (t.isNotEmpty() && playAnimation) {
-                        button_show_attachment_options.fadeInOrOut(1F, 0F, 120)
-                        button_send.fadeInOrOut(0F, 1F, 120)
-                        playAnimation = false
-                    }
-
-                    if (t.isEmpty()) {
-                        button_send.fadeInOrOut(1F, 0F, 120)
-                        button_show_attachment_options.fadeInOrOut(0F, 1F, 120)
-                        playAnimation = true
-                    }
-                })
+            subscribeTextMessage()
 
             button_send.setOnClickListener {
                 var message = citation ?: ""
                 message += text_message.textContent
                 sendMessage(message)
             }
-
 
             button_show_attachment_options.setOnClickListener {
                 if (layout_message_attachment_options.isShown) {
@@ -286,7 +271,9 @@ class ChatRoomFragment : Fragment(), ChatRoomView {
                 }
             }
 
-            view_dim.setOnClickListener { hideAttachmentOptions() }
+            view_dim.setOnClickListener {
+                hideAttachmentOptions()
+            }
 
             button_files.setOnClickListener {
                 handler.postDelayed({
@@ -305,6 +292,24 @@ class ChatRoomFragment : Fragment(), ChatRoomView {
         actionSnackbar.cancelView.setOnClickListener({
             clearMessageComposition()
         })
+    }
+
+    private fun subscribeTextMessage() {
+        var playAnimation = true
+        text_message.asObservable(0)
+            .subscribe({ t ->
+                if (t.isNotEmpty() && playAnimation) {
+                    button_show_attachment_options.fadeInOrOut(1F, 0F, 120)
+                    button_send.fadeInOrOut(0F, 1F, 120)
+                    playAnimation = false
+                }
+
+                if (t.isEmpty()) {
+                    button_send.fadeInOrOut(1F, 0F, 120)
+                    button_show_attachment_options.fadeInOrOut(0F, 1F, 120)
+                    playAnimation = true
+                }
+            })
     }
 
     private fun showAttachmentOptions() {

--- a/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsAdapter.kt
+++ b/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsAdapter.kt
@@ -18,6 +18,7 @@ import chat.rocket.core.model.ChatRoom
 import com.facebook.drawee.view.SimpleDraweeView
 import kotlinx.android.synthetic.main.avatar.view.*
 import kotlinx.android.synthetic.main.item_chat.view.*
+import kotlinx.android.synthetic.main.unread_messages_badge.view.*
 
 class ChatRoomsAdapter(private val context: Context,
                        private val listener: (ChatRoom) -> Unit) : RecyclerView.Adapter<ChatRoomsAdapter.ViewHolder>() {

--- a/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsAdapter.kt
+++ b/app/src/main/java/chat/rocket/android/chatrooms/ui/ChatRoomsAdapter.kt
@@ -1,19 +1,16 @@
 package chat.rocket.android.chatrooms.ui
 
 import DateTimeHelper
-import DrawableHelper
 import android.content.Context
 import android.support.v7.widget.RecyclerView
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import android.widget.TextView
 import chat.rocket.android.R
 import chat.rocket.android.helper.UrlHelper
 import chat.rocket.android.util.extensions.inflate
 import chat.rocket.android.util.extensions.setVisible
 import chat.rocket.android.util.extensions.textContent
-import chat.rocket.common.model.RoomType
 import chat.rocket.core.model.ChatRoom
 import com.facebook.drawee.view.SimpleDraweeView
 import kotlinx.android.synthetic.main.avatar.view.*

--- a/app/src/main/java/chat/rocket/android/util/extensions/Animation.kt
+++ b/app/src/main/java/chat/rocket/android/util/extensions/Animation.kt
@@ -12,7 +12,7 @@ fun View.rotateBy(value: Float, duration: Long = 200) {
         .start()
 }
 
-fun View.fadeInOrOut(startValue: Float, finishValue: Float, duration: Long = 200) {
+fun View.fadeIn(startValue: Float, finishValue: Float, duration: Long = 200) {
     animate()
         .alpha(startValue)
         .setDuration(duration)
@@ -24,11 +24,22 @@ fun View.fadeInOrOut(startValue: Float, finishValue: Float, duration: Long = 200
                 .setInterpolator(AccelerateInterpolator()).start()
         }).start()
 
-    if (startValue > finishValue) {
-        setVisible(false)
-    } else {
-        setVisible(true)
-    }
+    setVisible(true)
+}
+
+fun View.fadeOut(startValue: Float, finishValue: Float, duration: Long = 200) {
+    animate()
+        .alpha(startValue)
+        .setDuration(duration)
+        .setInterpolator(DecelerateInterpolator())
+        .withEndAction({
+            animate()
+                .alpha(finishValue)
+                .setDuration(duration)
+                .setInterpolator(AccelerateInterpolator()).start()
+        }).start()
+
+    setVisible(false)
 }
 
 fun View.circularRevealOrUnreveal(centerX: Int, centerY: Int, startRadius: Float, endRadius: Float, duration: Long = 600) {

--- a/app/src/main/java/chat/rocket/android/util/extensions/Ui.kt
+++ b/app/src/main/java/chat/rocket/android/util/extensions/Ui.kt
@@ -21,6 +21,10 @@ fun View.setVisible(visible: Boolean) {
     }
 }
 
+fun View.isVisible(): Boolean {
+    return visibility == View.VISIBLE
+}
+
 fun ViewGroup.inflate(@LayoutRes resource: Int): View = LayoutInflater.from(context).inflate(resource, this, false)
 
 fun AppCompatActivity.addFragment(tag: String, layoutId: Int, newInstance: () -> Fragment) {

--- a/app/src/main/res/drawable/ic_arrow_downward_24dp.xml
+++ b/app/src/main/res/drawable/ic_arrow_downward_24dp.xml
@@ -5,7 +5,7 @@
     android:viewportWidth="24.0">
 
     <path
-        android:fillColor="#010101"
+        android:fillColor="#FF010101"
         android:pathData="M20,12l-1.41,-1.41L13,16.17V4h-2v12.17l-5.58,-5.59L4,12l8,8 8,-8z" />
 
 </vector>

--- a/app/src/main/res/drawable/ic_arrow_downward_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_arrow_downward_black_24dp.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+
+    <path
+        android:fillColor="#010101"
+        android:pathData="M20,12l-1.41,-1.41L13,16.17V4h-2v12.17l-5.58,-5.59L4,12l8,8 8,-8z" />
+
+</vector>

--- a/app/src/main/res/layout/fragment_chat_room.xml
+++ b/app/src/main/res/layout/fragment_chat_room.xml
@@ -4,8 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
     <com.wang.avi.AVLoadingIndicatorView
         android:id="@+id/view_loading"
@@ -20,15 +19,22 @@
     <FrameLayout
         android:id="@+id/message_list_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_above="@+id/layout_message_composer">
 
-        <android.support.v7.widget.RecyclerView
-            android:id="@+id/recycler_view"
+        <include
+            android:id="@+id/layout_message_list"
+            layout="@layout/message_list"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scrollbars="vertical" />
+            android:layout_height="match_parent" />
     </FrameLayout>
+
+    <include
+        android:id="@+id/layout_message_composer"
+        layout="@layout/message_composer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true" />
 
     <View
         android:id="@+id/view_dim"
@@ -45,14 +51,6 @@
         android:layout_height="wrap_content"
         android:layout_above="@+id/layout_message_composer"
         android:layout_margin="5dp"
-        android:visibility="gone"
-        tools:visibility="visible" />
-
-    <include
-        android:id="@+id/layout_message_composer"
-        layout="@layout/message_composer"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true" />
+        android:visibility="gone" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/item_chat.xml
+++ b/app/src/main/res/layout/item_chat.xml
@@ -78,23 +78,16 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:layout_constraintBottom_toTopOf="@+id/guideline_one"
-            app:layout_constraintRight_toRightOf="@+id/text_total_unread_messages"
+            app:layout_constraintRight_toRightOf="@+id/layout_unread_messages_badge"
             tools:text="11:45" />
 
-        <TextView
-            android:id="@+id/text_total_unread_messages"
-            style="@style/TextAppearance.AppCompat.Caption"
+        <include
+            android:id="@+id/layout_unread_messages_badge"
+            layout="@layout/unread_messages_badge"
             android:layout_width="20dp"
             android:layout_height="20dp"
-            android:background="@drawable/style_total_unread_messages"
-            android:gravity="center"
-            android:textColor="@color/white"
-            android:textSize="10sp"
-            android:visibility="gone"
             app:layout_constraintBottom_toTopOf="@+id/guideline_two"
-            app:layout_constraintRight_toRightOf="parent"
-            tools:text="99+"
-            tools:visibility="visible" />
+            app:layout_constraintRight_toRightOf="parent" />
 
         <android.support.constraint.Guideline
             android:id="@+id/guideline_one"

--- a/app/src/main/res/layout/message_list.xml
+++ b/app/src/main/res/layout/message_list.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scrollbars="vertical" />
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/button_fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:src="@drawable/ic_arrow_downward_black_24dp"
+        android:theme="@style/Theme.AppCompat"
+        android:tint="@color/gray_material"
+        android:visibility="invisible"
+        app:backgroundTint="@color/white"
+        app:fabSize="mini"
+        app:layout_anchor="@id/recycler_view"
+        app:layout_anchorGravity="bottom|end" />
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/message_list.xml
+++ b/app/src/main/res/layout/message_list.xml
@@ -15,7 +15,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="16dp"
-        android:src="@drawable/ic_arrow_downward_black_24dp"
+        android:src="@drawable/ic_arrow_downward_24dp"
         android:theme="@style/Theme.AppCompat"
         android:tint="@color/gray_material"
         android:visibility="invisible"

--- a/app/src/main/res/layout/unread_messages_badge.xml
+++ b/app/src/main/res/layout/unread_messages_badge.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/text_total_unread_messages"
+        style="@style/TextAppearance.AppCompat.Caption"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:background="@drawable/style_total_unread_messages"
+        android:gravity="center"
+        android:textColor="@color/white"
+        android:textSize="10sp"
+        android:visibility="gone"
+        tools:text="99+"
+        tools:visibility="visible" />
+
+</LinearLayout>


### PR DESCRIPTION
Also,

- Keeps the keyboard open after sending a message.
- Shows the entire new message when it arrives on the chat room.
- Adds a widget to easily show the latest messages when moving the list up.

Closes #757