### PR TITLE
[FIX] Allow colon(:) in server url

### DIFF
--- a/app/src/main/res/layout/fragment_authentication_server.xml
+++ b/app/src/main/res/layout/fragment_authentication_server.xml
@@ -32,7 +32,7 @@
         android:cursorVisible="false"
         android:hint="@string/default_server"
         android:imeOptions="actionDone"
-        android:digits="0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-/"
+        android:digits="0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-/:"
         android:inputType="textUri"
         android:paddingEnd="0dp"
         android:paddingStart="0dp" />


### PR DESCRIPTION
@RocketChat/android

Closes #806 

*Changes*
 - Added colon(:) in allowed characters for server url EditText view