### PR TITLE
[IMPROVEMENT] Fixed Layout for Login Screen

### DIFF
--- a/app/src/main/java/chat/rocket/android/authentication/login/ui/LoginFragment.kt
+++ b/app/src/main/java/chat/rocket/android/authentication/login/ui/LoginFragment.kt
@@ -12,6 +12,7 @@ import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import android.widget.ImageButton
 import android.widget.ScrollView
+
 import chat.rocket.android.R
 import chat.rocket.android.authentication.login.presentation.LoginPresenter
 import chat.rocket.android.authentication.login.presentation.LoginView
@@ -22,6 +23,7 @@ import chat.rocket.android.util.extensions.inflate
 import chat.rocket.android.util.extensions.setVisible
 import chat.rocket.android.util.extensions.showToast
 import chat.rocket.android.util.extensions.textContent
+
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_authentication_log_in.*
 import javax.inject.Inject

--- a/app/src/main/java/chat/rocket/android/authentication/login/ui/LoginFragment.kt
+++ b/app/src/main/java/chat/rocket/android/authentication/login/ui/LoginFragment.kt
@@ -74,6 +74,12 @@ class LoginFragment : Fragment(), LoginView {
         setupSignUpListener()
     }
 
+    override fun onViewStateRestored(savedInstanceState: Bundle?) {
+        super.onViewStateRestored(savedInstanceState)
+
+        isSocialMediaNeeded()
+    }
+
     private fun showThreeSocialMethods() {
         var count = 0
         for (i in 0..social_accounts_container.childCount) {
@@ -213,14 +219,20 @@ class LoginFragment : Fragment(), LoginView {
         button_log_in.isEnabled = value
         text_username_or_email.isEnabled = value
         text_password.isEnabled = value
-        if (!isEditTextEmpty()) {
-            showSignUpView(value)
-            showOauthView(value)
-        }
     }
 
     // Returns true if *all* EditTexts are empty.
     private fun isEditTextEmpty(): Boolean = text_username_or_email.textContent.isBlank() && text_password.textContent.isEmpty()
+
+    private fun isSocialMediaNeeded() {
+        if (!isEditTextEmpty()) {
+            showSignUpView(false)
+            showOauthView(false)
+        } else {
+            showSignUpView(true)
+            showOauthView(true)
+        }
+    }
 
     private fun showRemainingSocialAccountsView() {
         social_accounts_container.postDelayed({

--- a/app/src/main/java/chat/rocket/android/authentication/login/ui/LoginFragment.kt
+++ b/app/src/main/java/chat/rocket/android/authentication/login/ui/LoginFragment.kt
@@ -31,18 +31,9 @@ class LoginFragment : Fragment(), LoginView {
     @Inject lateinit var appContext: Context // TODO we really need it? Check alternatives...
 
     private val layoutListener = ViewTreeObserver.OnGlobalLayoutListener {
-        if (KeyboardHelper.isSoftKeyboardShown(scroll_view.rootView)) {
-            showSignUpView(false)
-            showOauthView(false)
-            showLoginButton(true)
-        } else {
-            if (isEditTextEmpty()) {
-                showSignUpView(true)
-                showOauthView(true)
-                showLoginButton(false)
-            }
-        }
+        areLoginOptionsNeeded()
     }
+
     private var isGlobalLayoutListenerSetUp = false
 
     companion object {
@@ -77,18 +68,7 @@ class LoginFragment : Fragment(), LoginView {
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
         super.onViewStateRestored(savedInstanceState)
 
-        isSocialMediaNeeded()
-    }
-
-    private fun showThreeSocialMethods() {
-        var count = 0
-        for (i in 0..social_accounts_container.childCount) {
-            val view = social_accounts_container.getChildAt(i) as? ImageButton ?: continue
-            if (view.isEnabled && count < 3) {
-                view.visibility = View.VISIBLE
-                count++
-            }
-        }
+        areLoginOptionsNeeded()
     }
 
     override fun onDestroyView() {
@@ -185,6 +165,17 @@ class LoginFragment : Fragment(), LoginView {
 
     override fun showNoInternetConnection() = showMessage(getString(R.string.msg_no_internet_connection))
 
+    private fun areLoginOptionsNeeded() {
+        if (!isEditTextEmpty() || KeyboardHelper.isSoftKeyboardShown(scroll_view.rootView)) {
+            showSignUpView(false)
+            showOauthView(false)
+            showLoginButton(true)
+        } else {
+            showSignUpView(true)
+            showOauthView(true)
+            showLoginButton(false)
+        }
+    }
 
     private fun tintEditTextDrawableStart() {
         activity?.apply {
@@ -224,16 +215,6 @@ class LoginFragment : Fragment(), LoginView {
     // Returns true if *all* EditTexts are empty.
     private fun isEditTextEmpty(): Boolean = text_username_or_email.textContent.isBlank() && text_password.textContent.isEmpty()
 
-    private fun isSocialMediaNeeded() {
-        if (!isEditTextEmpty()) {
-            showSignUpView(false)
-            showOauthView(false)
-        } else {
-            showSignUpView(true)
-            showOauthView(true)
-        }
-    }
-
     private fun showRemainingSocialAccountsView() {
         social_accounts_container.postDelayed({
             for (i in 0..social_accounts_container.childCount) {
@@ -241,6 +222,17 @@ class LoginFragment : Fragment(), LoginView {
                 if (view.isEnabled) view.visibility = View.VISIBLE
             }
         }, 1000)
+    }
+
+    private fun showThreeSocialMethods() {
+        var count = 0
+        for (i in 0..social_accounts_container.childCount) {
+            val view = social_accounts_container.getChildAt(i) as? ImageButton ?: continue
+            if (view.isEnabled && count < 3) {
+                view.visibility = View.VISIBLE
+                count++
+            }
+        }
     }
 
     private fun scrollToBottom() {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #819 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
**Information**
This pull request fixes the issue of having the social media interface show up after a failed log-in or just as the fragment is switching. It also fixes the same problem for when a user goes back from the TwoFA screen to the Login screen.

**Changes Made**

- Removed checking whether the social interface needed to be displayed or not from the `enableUserInput(value: Boolean)` method (this is not needed since the login button isn't displayed until the user has either entered text in the user-name or password or is focused on a text field and when there is no text, an API call isn't even attempted).
- Created `areLoginOptionsNeeded()` to check if the login button, social media interface, or sign up view are needed. Used this method for the listener and when the view state is retrieved.

**Screenshot**
<img src="https://user-images.githubusercontent.com/17170253/36770534-b97f7dbc-1c18-11e8-9441-6ed6d0604130.png" width="40%" height="40%">

