### PR TITLE
[FIX] Behavior of messages with attachments/previews

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatroom/adapter/ChatRoomAdapter.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/adapter/ChatRoomAdapter.kt
@@ -87,11 +87,13 @@ class ChatRoomAdapter(
     }
 
     fun prependData(dataSet: List<BaseViewModel<*>>) {
-        val lastMessage = this.dataSet.first()
-        val lastId = lastMessage.messageId
-        val lastType = lastMessage.viewType
-        this.dataSet.addAll(0, dataSet.filterNot { lastType == it.viewType && lastId == it.messageId })
-        notifyItemRangeInserted(0, dataSet.size)
+        val item = dataSet.firstOrNull { newItem ->
+            this.dataSet.indexOfFirst { it.messageId == newItem.messageId && it.viewType == newItem.viewType } > -1
+        }
+        if (item == null) {
+            this.dataSet.addAll(0, dataSet)
+            notifyItemRangeInserted(0, dataSet.size)
+        }
     }
 
     fun updateItem(message: BaseViewModel<*>) {

--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
@@ -213,9 +213,8 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardPopup.Listener {
     }
 
     override fun dispatchUpdateMessage(index: Int, message: List<BaseViewModel<*>>) {
-        if (message.size == 1) {
-            adapter.updateItem(message.last())
-        } else {
+        adapter.updateItem(message.last())
+        if (message.size > 1) {
             adapter.updateItem(message.last())
             adapter.prependData(listOf(message.first()))
         }

--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
@@ -213,7 +213,12 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardPopup.Listener {
     }
 
     override fun dispatchUpdateMessage(index: Int, message: List<BaseViewModel<*>>) {
-        adapter.updateItem(message.last())
+        if (message.size == 1) {
+            adapter.updateItem(message.last())
+        } else {
+            adapter.updateItem(message.last())
+            adapter.prependData(listOf(message.first()))
+        }
     }
 
     override fun dispatchDeleteMessage(msgId: String) {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

- Showing preview of urls that were just sent was broken.
- Deleting messages with attachments or url previews now work as intended. Previously only the message was removed from the list not its related attachment.

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #870, #875 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->