### PR TITLE
[IMPROVEMENT] Add ripple effect on recyclerview items

### DIFF
--- a/app/src/main/res/layout/item_chat.xml
+++ b/app/src/main/res/layout/item_chat.xml
@@ -4,10 +4,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="12dp"
-    android:layout_marginEnd="@dimen/screen_edge_left_and_right_margins"
-    android:layout_marginStart="@dimen/screen_edge_left_and_right_margins"
-    android:layout_marginTop="12dp">
+    android:background="?android:attr/selectableItemBackground"
+    android:paddingStart="@dimen/screen_edge_left_and_right_padding"
+    android:paddingEnd="@dimen/screen_edge_left_and_right_padding"
+    android:paddingTop="@dimen/chat_item_top_and_bottom_padding"
+    android:paddingBottom="@dimen/chat_item_top_and_bottom_padding">
 
     <include
         android:id="@+id/layout_avatar"

--- a/app/src/main/res/layout/item_member.xml
+++ b/app/src/main/res/layout/item_member.xml
@@ -4,10 +4,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="6dp"
-    android:layout_marginEnd="@dimen/screen_edge_left_and_right_margins"
-    android:layout_marginStart="@dimen/screen_edge_left_and_right_margins"
-    android:layout_marginTop="6dp">
+    android:background="?android:attr/selectableItemBackground"
+    android:paddingBottom="@dimen/member_item_top_and_bottom_padding"
+    android:paddingEnd="@dimen/screen_edge_left_and_right_padding"
+    android:paddingStart="@dimen/screen_edge_left_and_right_padding"
+    android:paddingTop="@dimen/member_item_top_and_bottom_padding">
 
     <include
         android:id="@+id/layout_avatar"

--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -4,10 +4,13 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="6dp"
-    android:layout_marginEnd="@dimen/screen_edge_left_and_right_margins"
-    android:layout_marginStart="@dimen/screen_edge_left_and_right_margins"
-    android:layout_marginTop="6dp">
+    android:background="?android:attr/selectableItemBackground"
+    android:clickable="true"
+    android:paddingStart="@dimen/screen_edge_left_and_right_padding"
+    android:paddingEnd="@dimen/screen_edge_left_and_right_padding"
+    android:paddingTop="@dimen/message_item_top_and_bottom_padding"
+    android:paddingBottom="@dimen/message_item_top_and_bottom_padding"
+    android:focusable="true">
 
     <include
         android:id="@+id/layout_avatar"

--- a/app/src/main/res/layout/message_attachment.xml
+++ b/app/src/main/res/layout/message_attachment.xml
@@ -5,6 +5,7 @@
     android:id="@+id/attachment_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?android:attr/selectableItemBackground"
     android:paddingStart="72dp"
     android:paddingEnd="@dimen/screen_edge_left_and_right_margins"
     android:orientation="vertical">

--- a/app/src/main/res/layout/message_url_preview.xml
+++ b/app/src/main/res/layout/message_url_preview.xml
@@ -6,6 +6,7 @@
     android:id="@+id/url_preview_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?android:attr/selectableItemBackground"
     android:paddingStart="72dp"
     android:paddingEnd="24dp">
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -4,6 +4,11 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="screen_edge_left_and_right_margins">16dp</dimen>
 
+    <dimen name="screen_edge_left_and_right_padding">16dp</dimen>
+    <dimen name="chat_item_top_and_bottom_padding">12dp</dimen>
+    <dimen name="message_item_top_and_bottom_padding">6dp</dimen>
+    <dimen name="member_item_top_and_bottom_padding">6dp</dimen>
+
     <dimen name="edit_text_margin">10dp</dimen>
     <dimen name="edit_text_drawable_padding">16dp</dimen>
 


### PR DESCRIPTION
@RocketChat/android

Closes #883 

**Changes**
- Added ripple effect on ChatRoom, message, pinned message, member item using `selectableItemBackground` as background
- Changed margin to padding so that ripple effect cover area of device width