### PR TITLE
[FIX] Add landscape layout for profile fragment

### DIFF
--- a/app/src/main/java/chat/rocket/android/profile/ui/ProfileFragment.kt
+++ b/app/src/main/java/chat/rocket/android/profile/ui/ProfileFragment.kt
@@ -62,6 +62,7 @@ class ProfileFragment : Fragment(), ProfileView, ActionMode.Callback {
         currentAvatar = avatarUrl
 
         profile_container.setVisible(true)
+        layout_avatar_profile.setVisible(true)
 
         listenToChanges()
     }

--- a/app/src/main/res/layout-land/fragment_profile.xml
+++ b/app/src/main/res/layout-land/fragment_profile.xml
@@ -8,11 +8,21 @@
     android:focusableInTouchMode="true"
     tools:context=".profile.ui.ProfileFragment">
 
+    <include
+        android:id="@+id/layout_avatar_profile"
+        layout="@layout/avatar_profile"
+        android:visibility="gone"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:layout_marginStart="16dp"/>
+
     <ScrollView
         android:id="@+id/profile_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center"
+        android:layout_toEndOf="@id/layout_avatar_profile"
         android:visibility="gone">
 
         <LinearLayout
@@ -21,17 +31,10 @@
             android:gravity="center"
             android:orientation="vertical">
 
-            <include
-                android:id="@+id/layout_avatar_profile"
-                layout="@layout/avatar_profile"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="32dp" />
-
             <EditText
                 android:id="@+id/text_name"
                 style="@style/Profile.EditText"
-                android:layout_marginTop="32dp"
+                android:layout_marginTop="16dp"
                 android:drawableStart="@drawable/ic_person_black_24dp"
                 android:hint="@string/msg_name"
                 android:inputType="textCapWords" />
@@ -56,6 +59,7 @@
                 android:id="@+id/text_avatar_url"
                 style="@style/Profile.EditText"
                 android:layout_marginTop="16dp"
+                android:layout_marginBottom="16dp"
                 android:drawableStart="@drawable/ic_link_black_24dp"
                 android:hint="@string/msg_avatar_url"
                 android:inputType="text" />


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #851 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Added a `ScrollView` over the existing `LinearLayout` (`@id/layout_avatar_profile`) for both portrait and landscape layouts. Further, created a new landscape layout which rearranges the elements to better use the available space.

![rocket_chat_profile](https://user-images.githubusercontent.com/22165670/37255956-3779f5ac-257a-11e8-825b-9bf3abf96e8e.png)
