### PR TITLE
[ENHANCEMENT] Scroll to message when keyboard opened

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
@@ -440,13 +440,16 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardListener, EmojiR
             subscribeTextMessage()
             emojiKeyboardPopup = EmojiKeyboardPopup(activity!!, activity!!.findViewById(R.id.fragment_container))
             emojiKeyboardPopup.listener = this
+
             text_message.listener = object : ComposerEditText.ComposerEditTextListener {
                 override fun onKeyboardOpened() {
-                    if (recycler_view.isAtBottom()) {
+                    var index = 0
+                    if (!recycler_view.isNearBottom()) {
                         if (adapter.itemCount > 0) {
-                            recycler_view.scrollToPosition(0)
+                            index = (recycler_view.layoutManager as LinearLayoutManager).findFirstVisibleItemPosition()
                         }
                     }
+                    handler.postDelayed({recycler_view.scrollToPosition(index)}, 300)
                 }
 
                 override fun onKeyboardClosed() {

--- a/app/src/main/java/chat/rocket/android/util/extensions/Ui.kt
+++ b/app/src/main/java/chat/rocket/android/util/extensions/Ui.kt
@@ -66,3 +66,12 @@ fun RecyclerView.isAtBottom(): Boolean {
 
     return false // or true??? we can't determine the first visible item.
 }
+
+fun RecyclerView.isNearBottom(): Boolean {
+    val manager: RecyclerView.LayoutManager? = layoutManager
+    if (manager is LinearLayoutManager) {
+        return manager.findFirstVisibleItemPosition() <= 3 // custom message threshold
+    }
+
+    return false
+}

--- a/app/src/main/java/chat/rocket/android/widget/emoji/ComposerEditText.kt
+++ b/app/src/main/java/chat/rocket/android/widget/emoji/ComposerEditText.kt
@@ -1,12 +1,14 @@
 package chat.rocket.android.widget.emoji
 
 import android.content.Context
+import android.graphics.Rect
 import android.support.v7.widget.AppCompatEditText
 import android.util.AttributeSet
 import android.view.KeyEvent
 
 class ComposerEditText : AppCompatEditText {
     var listener: ComposerEditTextListener? = null
+    var isKeyboardOpen = false
 
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) :
             super(context, attrs, defStyleAttr) {
@@ -27,6 +29,7 @@ class ComposerEditText : AppCompatEditText {
                 if (event.action == KeyEvent.ACTION_DOWN) {
                     state.startTracking(event, this)
                     listener?.onKeyboardClosed()
+                    isKeyboardOpen = false
                 }
                 return true
             }
@@ -35,8 +38,22 @@ class ComposerEditText : AppCompatEditText {
     }
 
     override fun performClick(): Boolean {
-        listener?.onKeyboardOpened()
+        // Do not trigger event if the keyboard is already visible
+        if (!isKeyboardOpen) {
+            listener?.onKeyboardOpened()
+            isKeyboardOpen = true
+        }
+
         return super.performClick()
+    }
+
+    override fun onFocusChanged(focused: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
+        // To handle the first click that isn't being detected by performClick()
+        if (focused && !isKeyboardOpen) {
+            performClick()
+        }
+
+        super.onFocusChanged(focused, direction, previouslyFocusedRect)
     }
 
     interface ComposerEditTextListener {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #872 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
The existing `onKeyboardOpened` callback had an issue where the first click was not detected by `performClick()`. Further, eventual clicks on the text field while the keyboard were open also triggered the event.

A boolean was added to ensure the callback only triggered when the keyboard was not already open. To handle the first click, `onFocusChanged` was overridden and `performClick` called through it manually.

In `ChatRoomFragment.kt`, the `scrollToPosition` method was not behaving as intended due to being executed before the resizing of views. Hence, the method was put into a `Handler` and posted after a delay.  (A similar method call exists in the `showReplyingAction()` function [here](https://github.com/TheGamer007/Rocket.Chat.Android/blob/92cc58c3b92b8eb146bd10eb65d4debb4be505d9/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt#L262), but it was left unchanged since no issues were reported with it).

Based on the discussion at the original issue, a message threshold of `3` has been applied below which it scrolls directly to the bottom. Above this, it scrolls to the bottom-most visible element. This can be tweaked a bit to center a more appropriate item, like the one above it or the bottom-most _completely_ visible element. 

The only potential issue I've seen with scrolling for each item is that if a message has very long content, then it tends to scroll either to the top or bottom of that message. For normal messages, it neatly brings them into view.