### PR TITLE
[FIX] Properly mark a room as read

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomPresenter.kt
@@ -71,12 +71,12 @@ class ChatRoomPresenter @Inject constructor(private val view: ChatRoomView,
                         client.messages(chatRoomId, roomTypeOf(chatRoomType), offset, 30).result
                 messagesRepository.saveAll(messages)
 
+                val messagesViewModels = mapper.map(messages)
+                view.showMessages(messagesViewModels)
+
                 // TODO: For now we are marking the room as read if we can get the messages (I mean, no exception occurs)
                 // but should mark only when the user see the first unread message.
                 markRoomAsRead(chatRoomId)
-
-                val messagesViewModels = mapper.map(messages)
-                view.showMessages(messagesViewModels)
 
                 subscribeMessages(chatRoomId)
             } catch (ex: Exception) {
@@ -230,6 +230,9 @@ class ChatRoomPresenter @Inject constructor(private val view: ChatRoomView,
     fun unsubscribeMessages(chatRoomId: String) {
         manager.removeStatusChannel(stateChannel)
         manager.unsubscribeRoomMessages(chatRoomId)
+        // All messages during the subscribed period are assumed to be read,
+        // and lastSeen is updated as the time when the user leaves the room
+        markRoomAsRead(chatRoomId)
     }
 
     /**

--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -35,13 +35,20 @@
             android:layout_height="1dp"
             android:layout_width="0dp"
             android:layout_weight="1"
-            android:layout_marginRight="4dp"
+            android:layout_marginEnd="4dp"
             android:background="@color/red"/>
         <TextView
             android:layout_width="wrap_content"
             android:text="@string/msg_unread_messages"
             android:layout_height="wrap_content"
             android:textColor="@color/red" />
+        <View
+            android:layout_gravity="center"
+            android:layout_height="1dp"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_marginStart="4dp"
+            android:background="@color/red"/>
     </LinearLayout>
 
     <LinearLayout


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #900

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Currently, the `markRoomAsRead()` function is called just once before displaying the messages. This messes up the unread marker display, so it has  been shifted to below the `loadMessages()` call.

New messages after the user joining the room are handled by `subscribeMessages()` function, and this subscription is removed when the user exits via the `unsubscribeMessages()` function. Since the method marks the entire room as read and not on a per message basis, a call to `markRoomAsRead()` has been added to `unsubscribeMessages()`. This seems to have fixed the issue.

PS: I am assuming it is desirable to mark the entire room as read when the user views and exits the room. There seems to be a `TODO` comment about marking only when the first unread message is read, and not otherwise. If that is the case, a slightly different approach will be needed.