### PR TITLE
[IMPROVEMENT] Capitalize socket connection status strings

### DIFF
--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -130,12 +130,12 @@
     <string name="max_file_size_exceeded">Tamanho de arquivo (%1$d bytes) excedeu tamanho máximo de upload (%2$d bytes)</string>
 
     <!-- Socket status -->
-    <string name="status_connected">conectado</string>
-    <string name="status_disconnected">desconetado</string>
-    <string name="status_connecting">conectando</string>
-    <string name="status_authenticating">autenticando</string>
-    <string name="status_disconnecting">desconectando</string>
-    <string name="status_waiting">conectando em %d segundos</string>
+    <string name="status_connected">Conectado</string>
+    <string name="status_disconnected">Desconetado</string>
+    <string name="status_connecting">Conectando</string>
+    <string name="status_authenticating">Autenticando</string>
+    <string name="status_disconnecting">Desconectando</string>
+    <string name="status_waiting">Conectando em %d segundos</string>
 
     <!--Suggestions-->
     <string name="suggest_all_description">Notifica todos nesta sala</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,12 +131,12 @@
     <string name="max_file_size_exceeded">File size %1$d bytes exceeded max upload size of %2$d bytes</string>
 
     <!-- Socket status -->
-    <string name="status_connected">connected</string>
-    <string name="status_disconnected">disconnected</string>
-    <string name="status_connecting">connecting</string>
-    <string name="status_authenticating">authenticating</string>
-    <string name="status_disconnecting">disconnecting</string>
-    <string name="status_waiting">connecting in %d seconds</string>
+    <string name="status_connected">Connected</string>
+    <string name="status_disconnected">Disconnected</string>
+    <string name="status_connecting">Connecting</string>
+    <string name="status_authenticating">Authenticating</string>
+    <string name="status_disconnecting">Disconnecting</string>
+    <string name="status_waiting">Connecting in %d seconds</string>
 
     <!--Suggestions-->
     <string name="suggest_all_description">Notify all in this room</string>


### PR DESCRIPTION
These strings are displayed to users, and accordingly, should be match the capitalization of other text.

@RocketChat/android