### PR TITLE
[IMPROVEMENT] Only allow Openable content in Storage Access Framework

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
@@ -467,6 +467,7 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardListener, EmojiR
             val intent = Intent(Intent.ACTION_GET_CONTENT)
             intent.type = "*/*"
             intent.putExtra(Intent.EXTRA_MIME_TYPES, filter)
+            intent.addCategory(Intent.CATEGORY_OPENABLE)
             startActivityForResult(intent, REQUEST_CODE_FOR_PERFORM_SAF)
         }
     }


### PR DESCRIPTION
Add the CATEGORY_OPENABLE to the Intent to launch the Storage Access Framework (SAF) when sending a file. Setting this category ensures that the OpenableColumns data contract is met by the opened data, which we rely upon during data upload.

In practice, some content, such as Contacts, will no longer display in the SAF UI.

Fixes #935

@RocketChat/android