### PR TITLE
Remove the request for READ_EXTERNAL_STORAGE permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 
     <permission

--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
@@ -1,18 +1,14 @@
 package chat.rocket.android.chatroom.ui
 
-import android.Manifest
 import android.app.Activity
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.support.annotation.DrawableRes
-import android.support.v4.app.ActivityCompat
 import android.support.v4.app.Fragment
-import android.support.v4.content.ContextCompat
 import android.support.v7.widget.DefaultItemAnimator
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
@@ -468,29 +464,10 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardListener, EmojiR
 
     override fun showFileSelection(filter: Array<String>) {
         ui {
-            if (ContextCompat.checkSelfPermission(it, Manifest.permission.READ_EXTERNAL_STORAGE)
-                != PackageManager.PERMISSION_GRANTED) {
-                ActivityCompat.requestPermissions(it,
-                    arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE),
-                    1)
-            } else {
-                val intent = Intent(Intent.ACTION_GET_CONTENT)
-                intent.type = "*/*"
-                intent.putExtra(Intent.EXTRA_MIME_TYPES, filter)
-                startActivityForResult(intent, REQUEST_CODE_FOR_PERFORM_SAF)
-            }
-        }
-    }
-
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
-        when (requestCode) {
-            1 -> {
-                if (!(grantResults.isNotEmpty() && grantResults.first() == PackageManager.PERMISSION_GRANTED)) {
-                    handler.postDelayed({
-                        ui { hideAttachmentOptions() }
-                    }, 400)
-                }
-            }
+            val intent = Intent(Intent.ACTION_GET_CONTENT)
+            intent.type = "*/*"
+            intent.putExtra(Intent.EXTRA_MIME_TYPES, filter)
+            startActivityForResult(intent, REQUEST_CODE_FOR_PERFORM_SAF)
         }
     }
 


### PR DESCRIPTION
We use the Storage Access Framework (SAF) to enable users to send files. When using the SAF, READ_EXTERNAL_STORAGE permission is not needed to read from internal storage, SD Cards, or anything else. The Android System is the one accessing the storage, so applications do not need direct access. This is in fact one of the major selling points of the SAF.

Note that no Google samples or apps by Google Developer Advocates that highlight the SAF request this permission.

Removing this permission is a good thing. Firstly, there are many SAF providers such as Google Drive, Photos, Microsoft OneDrive, etc, that do not use external storage. Secondly, users are not prompted for a needless permission. Thirdly, it reduces the complexity of the ChatRoomFragment.

@RocketChat/android