### PR TITLE
[IMPROVEMENT] Change ImagePipelineConfig initialization in Dagger graph

### DIFF
--- a/app/src/main/java/chat/rocket/android/dagger/module/AppModule.kt
+++ b/app/src/main/java/chat/rocket/android/dagger/module/AppModule.kt
@@ -38,7 +38,6 @@ import chat.rocket.core.internal.ReactionsAdapter
 import com.facebook.drawee.backends.pipeline.DraweeConfig
 import com.facebook.imagepipeline.backends.okhttp3.OkHttpImagePipelineConfigFactory
 import com.facebook.imagepipeline.core.ImagePipelineConfig
-import com.facebook.imagepipeline.listener.RequestListener
 import com.facebook.imagepipeline.listener.RequestLoggingListener
 import com.squareup.moshi.Moshi
 import dagger.Module
@@ -138,8 +137,7 @@ class AppModule {
     @Provides
     @Singleton
     fun provideImagePipelineConfig(context: Context, @ForFresco okHttpClient: OkHttpClient): ImagePipelineConfig {
-        val listeners = HashSet<RequestListener>()
-        listeners.add(RequestLoggingListener())
+        val listeners = setOf(RequestLoggingListener())
 
         return OkHttpImagePipelineConfigFactory.newBuilder(context, okHttpClient)
             .setRequestListeners(listeners)


### PR DESCRIPTION
Rather than creating a new, unsized HashSet, use idiomatic Kotlin to create the set of RequestListeners for the ImagePipelineConfig. Under the hood a SingletonSet will be used which is optimized for the current use case, but if additional Listeners are added, the collections will automatically be sized appropriately. This leads to better memory utilization and reduced CPU usage.

@RocketChat/android