### PR TITLE
[IMPROVEMENT] Change OkHttpClient initialization in Dagger graph

### DIFF
--- a/app/src/main/java/chat/rocket/android/dagger/module/AppModule.kt
+++ b/app/src/main/java/chat/rocket/android/dagger/module/AppModule.kt
@@ -111,12 +111,12 @@ class AppModule {
     @Provides
     @Singleton
     fun provideOkHttpClient(logger: HttpLoggingInterceptor): OkHttpClient {
-        return OkHttpClient.Builder().apply {
-            addInterceptor(logger)
-            connectTimeout(15, TimeUnit.SECONDS)
-            readTimeout(20, TimeUnit.SECONDS)
-            writeTimeout(15, TimeUnit.SECONDS)
-        }.build()
+        return OkHttpClient.Builder()
+                .addInterceptor(logger)
+                .connectTimeout(15, TimeUnit.SECONDS)
+                .readTimeout(20, TimeUnit.SECONDS)
+                .writeTimeout(15, TimeUnit.SECONDS)
+                .build()
     }
 
     @Provides


### PR DESCRIPTION
Rather than using the Kotlin apply function, directly invoke the builder methods on the OkHttpClient.Builder instance. This produces noticeably better bytecode and the apply function does not add value in this case.

@RocketChat/android