### PR TITLE
[FIX] File uploading when no filters are applied

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,9 @@ jobs:
       - run:
           name: Run Unit test
           command: ./gradlew test
+      - run:
+          name: Compile Instrumentation test
+          command: ./gradlew assembleAndroidTest
       - store_artifacts:
           path: app/build/reports/
           destination: reports

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -114,9 +114,9 @@ dependencies {
     }
 
     testImplementation libraries.junit
-    androidTestImplementation(libraries.expressoCore, {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
+    testImplementation libraries.truth
+    androidTestImplementation libraries.espressoCore
+    androidTestImplementation libraries.espressoIntents
 }
 
 kotlin {

--- a/app/src/androidTest/java/chat/rocket/android/chatroom/ui/ChatRoomFragmentTest.kt
+++ b/app/src/androidTest/java/chat/rocket/android/chatroom/ui/ChatRoomFragmentTest.kt
@@ -1,0 +1,58 @@
+package chat.rocket.android.chatroom.ui
+
+import android.content.Intent
+import android.support.test.espresso.intent.rule.IntentsTestRule
+import android.support.test.filters.LargeTest
+import org.junit.Rule
+import org.junit.Test
+import android.app.Activity
+import android.app.Instrumentation.ActivityResult
+import android.support.test.InstrumentationRegistry
+import android.support.test.espresso.intent.Intents.intended
+import android.support.test.espresso.intent.Intents.intending
+import android.support.test.espresso.intent.matcher.IntentMatchers.*
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.not
+import org.junit.Before
+
+@LargeTest
+class ChatRoomFragmentTest {
+
+    @JvmField
+    @Rule
+    val activityRule = IntentsTestRule<ChatRoomActivity>(ChatRoomActivity::class.java, false, false)
+
+    @Before
+    fun stubAllExternalIntents() {
+        val activityIntent = InstrumentationRegistry.getTargetContext().chatRoomIntent("id", "name", "type", false, 0L)
+        activityRule.launchActivity(activityIntent)
+        intending(not(isInternal())).respondWith(ActivityResult(Activity.RESULT_OK, null))
+    }
+
+    @Test
+    fun showFileSelection_nonNullFiltersAreApplied() {
+        val fragment = activityRule.activity.supportFragmentManager.findFragmentByTag(ChatRoomActivity.TAG_CHAT_ROOM_FRAGMENT) as ChatRoomFragment
+
+        val filters = arrayOf("image/*")
+        fragment.showFileSelection(filters)
+
+        intended(allOf(
+                hasAction(Intent.ACTION_GET_CONTENT),
+                hasType("*/*"),
+                hasCategories(setOf(Intent.CATEGORY_OPENABLE)),
+                hasExtra(Intent.EXTRA_MIME_TYPES, filters)))
+    }
+
+    @Test
+    fun showFileSelection_nullFiltersAreNotApplied() {
+        val fragment = activityRule.activity.supportFragmentManager.findFragmentByTag(ChatRoomActivity.TAG_CHAT_ROOM_FRAGMENT) as ChatRoomFragment
+
+        fragment.showFileSelection(null)
+
+        intended(allOf(
+                hasAction(Intent.ACTION_GET_CONTENT),
+                hasType("*/*"),
+                hasCategories(setOf(Intent.CATEGORY_OPENABLE)),
+                not(hasExtraWithKey(Intent.EXTRA_MIME_TYPES))))
+    }
+}

--- a/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomView.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomView.kt
@@ -28,7 +28,7 @@ interface ChatRoomView : LoadingView, MessageView {
     /**
      * Perform file selection with the mime type [filter]
      */
-    fun showFileSelection(filter: Array<String>)
+    fun showFileSelection(filter: Array<String>?)
 
     /**
      * Uploads a file to a chat room.

--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomActivity.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomActivity.kt
@@ -93,8 +93,8 @@ class ChatRoomActivity : AppCompatActivity(), HasSupportFragmentInjector {
 
         isChatRoomSubscribed = intent.getBooleanExtra(INTENT_CHAT_IS_SUBSCRIBED, true)
 
-        if (supportFragmentManager.findFragmentByTag("ChatRoomFragment") == null) {
-            addFragment("ChatRoomFragment", R.id.fragment_container) {
+        if (supportFragmentManager.findFragmentByTag(TAG_CHAT_ROOM_FRAGMENT) == null) {
+            addFragment(TAG_CHAT_ROOM_FRAGMENT, R.id.fragment_container) {
                 newInstance(chatRoomId, chatRoomName, chatRoomType, isChatRoomReadOnly, chatRoomLastSeen,
                         isChatRoomSubscribed)
             }
@@ -155,5 +155,9 @@ class ChatRoomActivity : AppCompatActivity(), HasSupportFragmentInjector {
     private fun finishActivity() {
         super.onBackPressed()
         overridePendingTransition(R.anim.close_enter, R.anim.close_exit)
+    }
+
+    companion object {
+        const val TAG_CHAT_ROOM_FRAGMENT = "ChatRoomFragment"
     }
 }

--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
@@ -485,12 +485,18 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardListener, EmojiR
         button_add_reaction.tag = drawableId
     }
 
-    override fun showFileSelection(filter: Array<String>) {
+    override fun showFileSelection(filter: Array<String>?) {
         ui {
             val intent = Intent(Intent.ACTION_GET_CONTENT)
+
+            // Must set a type otherwise the intent won't resolve
             intent.type = "*/*"
-            intent.putExtra(Intent.EXTRA_MIME_TYPES, filter)
             intent.addCategory(Intent.CATEGORY_OPENABLE)
+
+            // Filter selectable files to those that match the whitelist for this particular server
+            if (filter != null) {
+                intent.putExtra(Intent.EXTRA_MIME_TYPES, filter)
+            }
             startActivityForResult(intent, REQUEST_CODE_FOR_PERFORM_SAF)
         }
     }

--- a/app/src/main/java/chat/rocket/android/server/domain/SettingsRepository.kt
+++ b/app/src/main/java/chat/rocket/android/server/domain/SettingsRepository.kt
@@ -1,6 +1,5 @@
 package chat.rocket.android.server.domain
 
-import chat.rocket.android.util.extensions.mapToTypedArray
 import chat.rocket.core.model.Value
 
 typealias PublicSettings = Map<String, Value<Any>>
@@ -84,13 +83,16 @@ fun PublicSettings.allowedMessagePinning(): Boolean = this[ALLOW_MESSAGE_PINNING
 fun PublicSettings.allowedMessageEditing(): Boolean = this[ALLOW_MESSAGE_EDITING]?.value == true
 fun PublicSettings.allowedMessageDeleting(): Boolean = this[ALLOW_MESSAGE_DELETING]?.value == true
 
-fun PublicSettings.uploadMimeTypeFilter(): Array<String> {
-    val values = this[UPLOAD_WHITELIST_MIMETYPES]?.value
-    values?.let { it as String }?.split(",")?.let {
-        return it.mapToTypedArray { it.trim() }
+fun PublicSettings.uploadMimeTypeFilter(): Array<String>? {
+    val values = this[UPLOAD_WHITELIST_MIMETYPES]?.value as String?
+    if (!values.isNullOrBlank()){
+        // It's far more efficient to split the string to an array using the Java type rather than the Kotlin type
+        @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+        val filter = (values as java.lang.String).split(",")
+        filter.forEachIndexed { i, mimeType -> filter[i] = mimeType.trim() }
+        return filter
     }
-
-    return arrayOf("*/*")
+    return null
 }
 
 fun PublicSettings.uploadMaxFileSize(): Int {

--- a/app/src/main/java/chat/rocket/android/util/extensions/Collections.kt
+++ b/app/src/main/java/chat/rocket/android/util/extensions/Collections.kt
@@ -1,8 +1,0 @@
-package chat.rocket.android.util.extensions
-
-inline fun <T, reified R> List<T>.mapToTypedArray(transform: (T) -> R): Array<R> {
-    return when (this) {
-        is RandomAccess -> Array(size) { index -> transform(this[index]) }
-        else -> with(iterator()) { Array(size) { transform(next()) } }
-    }
-}

--- a/app/src/main/res/values/defaults.xml
+++ b/app/src/main/res/values/defaults.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="default_protocol" translatable="false">https://</string>
+    <string name="default_protocol" translatable="false">http://</string>
     <string name="default_server" translatable="false">open.rocket.chat</string>
 </resources>

--- a/app/src/test/java/chat/rocket/android/server/domain/SettingsRepositoryTest.kt
+++ b/app/src/test/java/chat/rocket/android/server/domain/SettingsRepositoryTest.kt
@@ -1,0 +1,14 @@
+package chat.rocket.android.server.domain
+
+import chat.rocket.core.model.Value
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class SettingsRepositoryTest {
+    @Test
+    fun `uploadMimeFilter returns null if not specified`() {
+        val settings = emptyMap<String, Value<Any>>()
+        val filter = settings.uploadMimeTypeFilter()
+        assertThat(filter).isNull()
+    }
+}

--- a/app/src/test/java/chat/rocket/android/server/domain/SettingsRepositoryUploadMimeFilterProperlyParsesWhitelistTest.kt
+++ b/app/src/test/java/chat/rocket/android/server/domain/SettingsRepositoryUploadMimeFilterProperlyParsesWhitelistTest.kt
@@ -1,0 +1,32 @@
+package chat.rocket.android.server.domain
+
+import chat.rocket.core.model.Value
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class `SettingsRepository UploadMimeTypeFilter WhitelistIsSet Test`(private val allowedMimeTypes: String,
+                                                                    private val expectedFilter: Array<String>?) {
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "\"{0}\"")
+        fun data(): Collection<Array<Any?>> = listOf(
+                arrayOf<Any?>("", null),
+                arrayOf<Any?>(" ", null),
+                arrayOf<Any?>("image/*", arrayOf("image/*")),
+                arrayOf<Any?>("image/*,video/*", arrayOf("image/*", "video/*")),
+                arrayOf<Any?>("image/*, video/*", arrayOf("image/*", "video/*")),
+                arrayOf<Any?>("image/*,\tvideo/*", arrayOf("image/*", "video/*"))
+        )
+    }
+
+    @Test
+    fun test() {
+        val settings = mapOf<String, Value<Any>>(Pair(UPLOAD_WHITELIST_MIMETYPES, Value(allowedMimeTypes)))
+        val filter = settings.uploadMimeTypeFilter()
+        assertThat(filter).isEqualTo(expectedFilter)
+    }
+}
+

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
             dokka                 : '0.9.16',
 
             // Main dependencies
-            support               : '27.1.0',
+            support               : '27.1.1',
             constraintLayout      : '1.0.2',
             androidKtx            : '0.3',
             dagger                : '2.14.1',
@@ -35,7 +35,7 @@ ext {
             // For testing
             junit                 : '4.12',
             truth                 : '0.36',
-            expresso              : '3.0.1',
+            espresso              : '3.0.2',
             mockito               : '2.10.0'
     ]
     libraries = [
@@ -98,7 +98,8 @@ ext {
 
             // For testing
             junit                 : "junit:junit:$versions.junit",
-            expressoCore          : "com.android.support.test.espresso:espresso-core:${versions.expresso}",
+            espressoCore          : "com.android.support.test.espresso:espresso-core:${versions.espresso}",
+            espressoIntents       : "com.android.support.test.espresso:espresso-intents:${versions.espresso}",
             roomTest              : "android.arch.persistence.room:testing:${versions.room}",
             truth                 : "com.google.truth:truth:$versions.truth",
     ]


### PR DESCRIPTION
When no file filters are specified in the server whitelist, the Android system is incorrectly given a mime type filter list including a single empty ("") mime type. Naturally, nothing matches this, and no documents can be selected for upload.

To remedy this, the application is changed to return a null filter array if filters are not to be applied.

@RocketChat/android