### PR TITLE
[FIX] Custom OAuth url

### DIFF
--- a/app/src/main/java/chat/rocket/android/helper/OauthHelper.kt
+++ b/app/src/main/java/chat/rocket/android/helper/OauthHelper.kt
@@ -84,7 +84,7 @@ object OauthHelper {
      * @return The Facebook Oauth URL.
      */
     fun getFacebookOauthUrl(clientId: String, serverUrl: String, state: String): String {
-        return  "https://facebook.com/v2.9/dialog/oauth" +
+        return "https://facebook.com/v2.9/dialog/oauth" +
                 "?client_id=$clientId" +
                 "&redirect_uri=${serverUrl.removeTrailingSlash()}/_oauth/facebook?close" +
                 "&state=$state" +
@@ -113,12 +113,18 @@ object OauthHelper {
         state: String,
         scope: String
     ): String {
-        return host +
-                authorizePath +
+        (authorizePath +
                 "?client_id=$clientId" +
                 "&redirect_uri=${serverUrl.removeTrailingSlash()}/_oauth/$serviceName" +
                 "&state=$state" +
                 "&scope=$scope" +
                 "&response_type=code"
+                ).let {
+            return if (it.contains(host)) {
+                it
+            } else {
+                host + it
+            }
+        }
     }
 }


### PR DESCRIPTION
The `authorizePath` can include the `host` itself, so before concatenate the `host` with the `authorizePath` check if the `host` is already present in the `authorizePath`.

Closes https://github.com/RocketChat/Rocket.Chat.Android/issues/1462