### PR TITLE
layout_avatar duplicate removed

### DIFF
--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -88,15 +88,6 @@
             android:background="@color/colorRed" />
     </LinearLayout>
 
-    <include
-        android:id="@+id/layout_avatar"
-        layout="@layout/avatar"
-        android:layout_width="38dp"
-        android:layout_height="40dp"
-        android:layout_marginTop="5dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/new_messages_notif" />
-
     <TextView
         android:id="@+id/text_sender"
         style="@style/Sender.Name.TextView"


### PR DESCRIPTION
layout_avatar duplicated in the layout, I've removed one of them

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
<img width="631" alt="screen shot 2018-08-17 at 12 33 32 pm" src="https://user-images.githubusercontent.com/3755157/44259308-d23e9900-a219-11e8-8b6d-327ac0b04621.png">
