### PR TITLE
[I18N] Add Japanese translation file

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,278 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<resources>
+    <string name="app_name" translatable="false">Rocket.Chat</string>
+
+    <!-- Titles -->
+    <string name="title_sign_in_your_server">サーバーに接続</string>
+    <string name="title_log_in">ログイン</string>
+    <string name="title_register_username">ユーザー名を登録する</string>
+    <string name="title_reset_password">パスワードリセット</string>
+    <string name="title_sign_up">サインアップ</string>
+    <string name="title_authentication">認証</string>
+    <string name="title_legal_terms">Legal Terms</string>
+    <string name="title_chats">チャット</string>
+    <string name="title_profile">プロフィール</string>
+    <string name="title_members">メンバー (%d)</string>
+    <string name="title_settings">設定</string>
+    <string name="title_password">パスワードの変更</string>
+    <string name="title_update_profile">プロフィールの更新</string>
+    <string name="title_about">About</string>
+    <string name="title_create_channel">新しいチャネルを作成します</string>
+
+    <!-- Actions -->
+    <string name="action_connect">接続</string>
+    <string name="action_use_this_username">このユーザー名を使用する</string>
+    <string name="action_login_or_sign_up">ログインまたはアカウントを作成するにはこのボタンを押してください</string>
+    <string name="action_terms_of_service">サービス利用規約</string>
+    <string name="action_privacy_policy">プライバシーポリシー</string>
+    <string name="action_search">検索</string>
+    <string name="action_update">更新</string>
+    <string name="action_settings">設定</string>
+    <string name="action_create_channel">チャンネル作成</string>
+    <string name="action_create">作ります</string>
+    <string name="action_logout">ログアウト</string>
+    <string name="action_files">ファイル</string>
+    <string name="action_confirm_password">変更したパスワードの確認</string>
+    <string name="action_join_chat">チャットに参加</string>
+    <string name="action_add_account">サーバーの追加</string>
+    <string name="action_online">オンライン</string>
+    <string name="action_away">離席中</string>
+    <string name="action_busy">取り込み中</string>
+    <string name="action_invisible">状態を隠す</string>
+    <string name="action_drawing">絵を描く</string>
+    <string name="action_save_to_gallery">ギャラリーに保存</string>
+
+    <!-- Settings List -->
+    <string-array name="settings_actions">
+        <item name="item_password">パスワードの変更</item>
+        <item name="item_password">このアプリケーションについて</item>
+    </string-array>
+
+    <!-- Regular information messages -->
+    <string name="msg_generic_error">エラーが発生しました。もう一度お試しください。</string>
+    <string name="msg_no_data_to_display">表示するデータがありません</string>
+    <string name="msg_profile_update_successfully">プロフィールの更新に成功しました</string>
+    <string name="msg_username">ユーザー名</string>
+    <string name="msg_username_or_email">メールアドレスまたはユーザー名</string>
+    <string name="msg_password">パスワード</string>
+    <string name="msg_name">名前</string>
+    <string name="msg_email">メール</string>
+    <string name="msg_avatar_url">アバター URL</string>
+    <string name="msg_or_continue_using_social_accounts">またはソーシャルアカウントを使用する</string>
+    <string name="msg_new_user">新規ユーザー? %1$s</string>
+    <string name="msg_forgot_password">パスワードをお忘れですか? %1$s</string>
+    <string name="msg_reset">リセット</string>
+    <string name="msg_check_your_email_to_reset_your_password">メールが送信されました! パスワードを変更するためには、受信ボックスを確認してください。</string>
+    <string name="msg_invalid_email">有効なメールアドレスを入力してください</string>
+    <string name="msg_new_user_agreement">サインアップすることで、\n%1$s と %2$s に同意したとみなします。</string>
+    <string name="msg_2fa_code">2FA コード</string>
+    <string name="msg_more_than_ninety_nine_unread_messages" translatable="false">99+</string>
+    <string name="msg_yesterday">昨日</string>
+    <string name="msg_message">メッセージ</string>
+    <string name="msg_this_room_is_read_only">この部屋は読み取り専用です</string>
+    <string name="msg_invalid_2fa_code">無効な 2FA コード</string>
+    <string name="msg_invalid_file">無効なファイル</string>
+    <string name="msg_invalid_server_url">無効なサーバー URL</string>
+    <string name="msg_content_description_log_in_using_facebook">Login using Facebook</string>
+    <string name="msg_content_description_log_in_using_github">Login using Github</string>
+    <string name="msg_content_description_log_in_using_google">Login using Google</string>
+    <string name="msg_content_description_log_in_using_linkedin">Login using Linkedin</string>
+    <string name="msg_content_description_log_in_using_meteor">Login using Meteor</string>
+    <string name="msg_content_description_log_in_using_twitter">Login using Twitter</string>
+    <string name="msg_content_description_log_in_using_gitlab">Login using Gitlab</string>
+    <string name="msg_content_description_send_message">メッセージを送信</string>
+    <string name="msg_content_description_show_attachment_options">添付ファイルオプションを表示する</string>
+    <string name="msg_you">あなた</string>
+    <string name="msg_unknown">不明</string>
+    <string name="msg_email_address">電子メールアドレス</string>
+    <string name="msg_utc_offset">UTC offset</string>
+    <string name="msg_new_password">新しいパスワード</string>
+    <string name="msg_confirm_password">新しいパスワードの確認</string>
+    <string name="msg_channel_name">チャンネル名</string>
+    <string name="msg_search">検索</string>
+    <string name="msg_unread_messages">未読メッセージ</string>
+    <string name="msg_preview_video">ビデオ</string>
+    <string name="msg_preview_audio">音声</string>
+    <string name="msg_preview_photo">写真</string>
+    <string name="msg_preview_file">ファイル</string>
+    <string name="msg_no_messages_yet">メッセージはまだありません</string>
+    <string name="msg_version">バージョン %1$s</string>
+    <string name="msg_build">ビルド %1$d</string>
+    <string name="msg_ok">OK</string>
+    <string name="msg_update_app_version_in_order_to_continue">古いバージョンのサーバーを使用しています。続行するには、管理者にサーバーのバージョンを更新するよう連絡してください。</string>
+    <string name="msg_ver_not_recommended">
+        ご使用のサーバーのバージョンは推薦バージョン %1$s よりも古いものです。\nログインは可能ですが、予期しない動作が発生する可能性があります。</string>
+    <string name="msg_ver_not_minimum">
+        サーバーのバージョンが最低限必要なバージョン %1$s よりも古いものです。\nサーバーのバージョンを更新してからログインしてください!
+    </string>
+    <string name="msg_no_chat_title">メッセージがまだありません</string>
+    <string name="msg_no_chat_description">ここから会話を始めましょう</string>
+    <string name="msg_proceed">PROCEED</string>
+    <string name="msg_cancel">キャンセル</string>
+    <string name="msg_warning">警告</string>
+    <string name="msg_http_insecure">HTTPを使用している場合、安全ではないサーバーに接続します。安全なサーバーに接続することをお勧めします。</string>
+    <string name="msg_error_checking_server_version">サーバーのバージョンを確認中にエラーが発生しました。もう一度お試しください。</string>
+    <string name="msg_invalid_server_protocol">選択したプロトコルはこのサーバーでは使用できません。HTTPSを選択してください。</string>
+    <string name="msg_image_saved_successfully">画像をギャラリーに保存しました</string>
+    <string name="msg_image_saved_failed">画像を保存できませんでした</string>
+    <string name="msg_edited">(編集済)</string>
+    <string name="msg_and">\u0020and\u0020</string>
+    <string name="msg_is_typing">\u0020is 入力中…</string>
+    <string name="msg_are_typing">\u0020are 入力中…</string>
+    <string name="msg_several_users_are_typing">複数のユーザーが入力中…</string>
+    <string name="msg_no_search_found">結果が見つかりません</string>
+    <string name="msg_log_out">ログアウト…</string>
+    <string name="msg_upload_file">ファイルをアップロード</string>
+    <string name="msg_file_description">ファイルの説明</string>
+    <string name="msg_send">送信</string>
+    <string name="msg_sent_attachment">添付ファイルを送信しました</string>
+
+    <!-- Create channel messages -->
+    <string name="msg_private_channel">プライベート</string>
+    <string name="msg_public_channel">パブリック</string>
+    <string name="msg_private_channel_description">招待されたユーザーだけがアクセスできます</string>
+    <string name="msg_public_channel_description">誰もがこのチャンネルにアクセスできます</string>
+    <string name="msg_ready_only_channel">読み取り専用チャネル</string>
+    <string name="msg_ready_only_channel_description">許可されたユーザーのみ新しいメッセージを書けます</string>
+    <string name="msg_invite_members">メンバーを招待する</string>
+    <string name="msg_member_already_added">あなたは既にこのユーザーを選択しています</string>
+    <string name="msg_member_not_found">メンバーが見つかりません</string>
+    <string name="msg_channel_created_successfully">チャンネルが正常に作成されました</string>
+    <string name="msg_message_copied">メッセージをコピー</string>
+    <string name="msg_delete_message">メッセージを削除</string>
+    <string name="msg_delete_description">このメッセージを削除してもよろしいですか?</string>
+
+    <!-- System messages -->
+    <string name="message_room_name_changed">ルーム名を %1$s から %2$s へ変更しました。</string>
+    <string name="message_user_added_by">%1$s がユーザー %2$s を追加しました。</string>
+    <string name="message_user_removed_by">%1$s がユーザー %2$s を削除しました。</string>
+    <string name="message_user_left">チャンネルを退去しました。</string>
+    <string name="message_user_joined_channel">チャンネルへ参加しました。</string>
+    <string name="message_welcome">ようこそ %s</string>
+    <string name="message_removed">メッセージを削除しました。</string>
+    <string name="message_pinned">メッセージをピン留めしました:</string>
+    <string name="message_muted">%2$sでミュートされたユーザー %1$s</string>
+    <string name="message_unmuted">ユーザー %1$s は %2$s によってミュートされていません</string>
+    <string name="message_role_add">%1$s は %3$s によって %2$s に設定されました</string>
+    <string name="message_role_removed">%1$s は %3$s で、もう %2$s ではありません</string>
+    <string name="message_credentials_saved_successfully">資格情報を正常に保存しました</string>
+
+    <!-- Message actions -->
+    <string name="action_msg_reply">返信</string>
+    <string name="action_msg_info">メッセージ情報</string>
+    <string name="action_msg_edit">編集</string>
+    <string name="action_msg_copy">コピー</string>
+    <string name="action_msg_quote">引用</string>
+    <string name="action_msg_delete">削除</string>
+    <string name="action_msg_pin">ピン留めする</string>
+    <string name="action_msg_unpin">ピン留を外す</string>
+    <string name="action_msg_star">スターをつける</string>
+    <string name="action_msg_unstar">スターを外す</string>
+    <string name="action_msg_share">Share</string>
+    <string name="action_title_editing">メッセージの編集</string>
+    <string name="action_msg_add_reaction">リアクションする</string>
+
+    <!-- Permission messages -->
+    <string name="permission_editing_not_allowed">編集は許可されていません</string>
+    <string name="permission_deleting_not_allowed">削除は許可されていません</string>
+    <string name="permission_pinning_not_allowed">ピン留めは許可されていません</string>
+    <string name="permission_starring_not_allowed">閲覧は許可されていません</string>
+
+    <!-- Search message -->
+    <string name="title_search_message">メッセージを検索</string>
+
+    <!-- Favorite/Unfavorite chat room -->
+    <string name="title_favorite_chat">お気に入り</string>
+    <string name="title_unfavorite_chat">お気に入り解除</string>
+
+    <!-- Members List -->
+    <string name="title_members_list">メンバー</string>
+
+    <!-- Mentions -->
+    <string name="msg_mentions">メンション</string>
+    <string name="msg_no_mention">メンションされたメッセージはありません</string>
+    <string name="msg_all_the_mentions_appear_here">全てのメンションされたメッセージが\ここに表示されます</string>
+
+    <!-- Pinned Messages -->
+    <string name="title_pinned_messages">ピン留めされたメッセージ</string>
+    <string name="no_pinned_messages">ピン留めされたメッセージはありません</string>
+    <string name="no_pinned_description">ピン留めされたすべてのメッセージが\ここに表示されます</string>
+
+    <!-- Favorite Messages -->
+    <string name="title_favorite_messages">お気に入りのメッセージ</string>
+    <string name="no_favorite_messages">お気に入りのメッセージはありません</string>
+    <string name="no_favorite_description">全てのお気に入りメッセージが\ここに表示されます</string>
+
+    <!-- Files -->
+    <string name="title_files">ファイル</string>
+    <string name="title_files_total">ファイル (%d)</string>
+    <string name="msg_no_files">ファイルがありません</string>
+    <string name="msg_all_files_appear_here">全てのファイルがここに表示されます</string>
+
+    <!-- Upload Messages -->
+    <string name="max_file_size_exceeded">ファイルサイズ %1$d バイトが最大アップロードサイズ %2$d バイトとを超えました</string>
+
+    <!-- Socket status -->
+    <string name="status_connected">接続済み</string>
+    <string name="status_disconnected">接続切断</string>
+    <string name="status_connecting">接続中</string>
+    <string name="status_authenticating">認証中</string>
+    <string name="status_disconnecting">切断</string>
+    <string name="status_waiting">%d 秒間接続中</string>
+
+    <!--Suggestions-->
+    <string name="suggest_all_description">このルームの全員に通知</string>
+    <string name="suggest_here_description">この部屋のアクティブユーザーに通知する</string>
+
+    <!-- Slash Commands -->
+    <string name="Slash_Gimme_Description">あなたのメッセージの前に表示（つ◕_◕）つ</string>
+    <string name="Slash_LennyFace_Description">あなたのメッセージの後に表示（͡°͜ʖ͡°）</string>
+    <string name="Slash_Shrug_Description">あなたのメッセージの後に表示¯\\ _（ツ）_ /¯</string>
+    <string name="Slash_Tableflip_Description">表示（╯°□°）╯(┻━┻</string>
+    <string name="Slash_TableUnflip_Description">表示┬─┬ノ（゜ - ゜ノ）</string>
+    <string name="Create_A_New_Channel">新しいチャネルを作成します</string>
+    <string name="Show_the_keyboard_shortcut_list">キーボードショートカットリストを表示する</string>
+    <string name="Invite_user_to_join_channel_all_from">[#channel]のすべてのユーザーをこのチャンネルに招待する</string>
+    <string name="Invite_user_to_join_channel_all_to">このチャンネルのすべてのユーザーを[#channel]に招待する</string>
+    <string name="Archive">アーカイブ</string>
+    <string name="Remove_someone_from_room">誰かをルームから削除</string>
+    <string name="Leave_the_current_channel">現在のチャンネルを残す</string>
+    <string name="Displays_action_text">操作テキストを表示</string>
+    <string name="Direct_message_someone">誰かへダイレクトメッセージ</string>
+    <string name="Mute_someone_in_room">誰かをルームでミュートにする</string>
+    <string name="Unmute_someone_in_room">誰かをルームでミュートを解除されました</string>
+    <string name="Invite_user_to_join_channel">ユーザーをこのチャンネルへ招待します</string>
+    <string name="Unarchive">アーカイブを解除</string>
+    <string name="Join_the_given_channel">チャンネルへ参加する</string>
+    <string name="Guggy_Command_Description">提供されたテキストに基づいてgifを生成する</string>
+    <string name="Slash_Topic_Description">設定トピック</string>
+
+    <!-- Emoji message-->
+    <string name="msg_no_recent_emoji">最近の絵文字はありません</string>
+    <string name="alert_title_default_skin_tone">デフォルトスキントークン</string>
+
+    <!-- Sorting and grouping-->
+    <string name="menu_chatroom_sort">ソート</string>
+    <string name="dialog_sort_title">ソート</string>
+    <string name="dialog_sort_by_alphabet">アルファベット順</string>
+    <string name="dialog_sort_by_activity">アクティビティで並べ替える</string>
+    <string name="dialog_group_by_type">グループ別</string>
+    <string name="dialog_group_favourites">お気に入りのグループ</string>
+    <string name="chatroom_header">ヘッダ</string>
+    <string name="dialog_button_done">完了</string>
+
+
+    <!--ChatRooms Headers-->
+    <string name="header_channel">チャンネル</string>
+    <string name="header_private_groups">プライベートグループ</string>
+    <string name="header_direct_messages">ダイレクトメッセージ</string>
+    <string name="header_live_chats">ライブチャット</string>
+    <string name="header_unknown">不明</string>
+
+    <!--Notifications-->
+    <string name="notif_action_reply_hint">返信</string>
+    <string name="notif_error_sending">送信に失敗しました。もう一度お試しください。</string>
+    <string name="notif_success_sending">メッセージは %1$s に送信されました!</string>
+    <string name="read_by">読者</string>
+    <string name="message_information_title">メッセージ情報</string>
+</resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -96,7 +96,7 @@
     <string name="msg_preview_photo">写真</string>
     <string name="msg_preview_file">ファイル</string>
     <string name="msg_no_messages_yet">メッセージはまだありません</string>
-    <string name="msg_version">バージョン %1$s</string>
+    <!--<string name="msg_version">バージョン %1$s</string>-->
     <string name="msg_build">ビルド %1$d</string>
     <string name="msg_ok">OK</string>
     <string name="msg_update_app_version_in_order_to_continue">古いバージョンのサーバーを使用しています。続行するには、管理者にサーバーのバージョンを更新するよう連絡してください。</string>


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

Add japanese translation file.
Japanese display became possible.
<img width="162" alt="screenshot_1535596263" src="https://user-images.githubusercontent.com/42823574/44826192-da023280-ac48-11e8-820f-705fe1406df6.png">
<img width="162" alt="screenshot_1535596572" src="https://user-images.githubusercontent.com/42823574/44826227-f56d3d80-ac48-11e8-9a7b-9f2de74ff092.png">

