### PR TITLE
[I18N] Russian translation

### DIFF
--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -145,7 +145,7 @@
 
     <!-- Preferences messages -->
     <string name="msg_analytics_tracking">Отслеживание Analytics</string>
-    <string name="msg_send_analytics_tracking">Отправлять анонимную статистику для улучшения приложения.</string> 
+    <string name="msg_send_analytics_tracking">Отправлять анонимную статистику для улучшения приложения.</string>
     <string name="msg_do_not_send_analytics_tracking">Не отправлять анонимную статистику для улучшения приложения</string>
     <string name="msg_not_applicable_since_it_is_a_foss_version">Не применимо, так как это FOSS версия</string>
 


### PR DESCRIPTION
Now the translation for Russia refers for its country, not for the entire federation.