### PR TITLE
[I18N] Fixed typo on Miembros string for Spanish language

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -9,7 +9,7 @@
     <string name="title_legal_terms">Términos legales</string>
     <string name="title_chats">Chats</string>
     <string name="title_profile">Perfil</string>
-    <string name="title_members">Miembros)</string>
+    <string name="title_members">Miembros</string>
     <string name="title_counted_members">Miembros (%d)</string>
     <string name="title_settings">Configuraciones</string>
     <string name="title_preferences">Preferences</string> <!-- TODO Add translation -->


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android
