### PR TITLE
[IMPROVEMENT] Dismiss emoji keyboard when starting search

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
@@ -271,7 +271,7 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardListener, EmojiR
         activity?.invalidateOptionsMenu()
     }
 
-    private fun dismissEmojiKeyboard() {
+    fun dismissEmojiKeyboard() {
         // Check if the keyboard was ever initialized.
         // It may be the case when you are looking a not joined room
         if (::emojiKeyboardPopup.isInitialized) {

--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
@@ -266,7 +266,6 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardListener, EmojiR
 
     override fun onPause() {
         super.onPause()
-        setReactionButtonIcon(R.drawable.ic_reaction_24dp)
         dismissEmojiKeyboard()
         activity?.invalidateOptionsMenu()
     }
@@ -276,6 +275,7 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardListener, EmojiR
         // It may be the case when you are looking a not joined room
         if (::emojiKeyboardPopup.isInitialized) {
             emojiKeyboardPopup.dismiss()
+            setReactionButtonIcon(R.drawable.ic_reaction_24dp)
         }
     }
 
@@ -784,8 +784,7 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardListener, EmojiR
                         context: Context
                     ) {
                         if (f is MessageActionsBottomSheet) {
-                            setReactionButtonIcon(R.drawable.ic_reaction_24dp)
-                            emojiKeyboardPopup.dismiss()
+                            dismissEmojiKeyboard()
                         }
                     }
                 },
@@ -805,9 +804,8 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardListener, EmojiR
                             it.onBackPressed()
                         }
                         KeyboardHelper.hideSoftKeyboard(it)
-                        emojiKeyboardPopup.dismiss()
+                        dismissEmojiKeyboard()
                     }
-                    setReactionButtonIcon(R.drawable.ic_reaction_24dp)
                 }
             }
 
@@ -917,8 +915,7 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardListener, EmojiR
             setReactionButtonIcon(R.drawable.ic_keyboard_black_24dp)
         } else {
             // If popup is showing, simply dismiss it to show the underlying text keyboard
-            emojiKeyboardPopup.dismiss()
-            setReactionButtonIcon(R.drawable.ic_reaction_24dp)
+            dismissEmojiKeyboard()
         }
     }
 

--- a/app/src/main/java/chat/rocket/android/chatroom/ui/Menu.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/Menu.kt
@@ -79,6 +79,14 @@ private fun ChatRoomFragment.setupSearchMessageMenuItem(menu: Menu, context: Con
         .setShowAsActionFlags(
             MenuItem.SHOW_AS_ACTION_IF_ROOM or MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW
         )
+        .setOnActionExpandListener(object : MenuItem.OnActionExpandListener {
+            override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
+                dismissEmojiKeyboard()
+                return true
+            }
+
+            override fun onMenuItemActionCollapse(item: MenuItem?) = true
+        })
 
     (searchItem?.actionView as? SearchView)?.let {
         // TODO: Check why we need to stylize the search text programmatically instead of by defining it in the styles.xml (ChatRoom.SearchView)

--- a/app/src/main/java/chat/rocket/android/chatroom/ui/Menu.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/Menu.kt
@@ -85,7 +85,10 @@ private fun ChatRoomFragment.setupSearchMessageMenuItem(menu: Menu, context: Con
                 return true
             }
 
-            override fun onMenuItemActionCollapse(item: MenuItem?) = true
+            override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
+                dismissEmojiKeyboard()
+                return true
+            }
         })
 
     (searchItem?.actionView as? SearchView)?.let {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #1658

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
This PR makes it so that whenever search input is expanded or collapsed emoji keyboard gets hidden.

![2018-10-20_12-16-03](https://user-images.githubusercontent.com/5156340/47254386-0e80b680-d462-11e8-92f1-e6784ae3a95d.gif)
