### PR TITLE
[FIX] Gif files not being animated.

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatroom/ui/Dialog.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/Dialog.kt
@@ -7,6 +7,7 @@ import androidx.core.view.isVisible
 import chat.rocket.android.emoji.internal.GlideApp
 import chat.rocket.android.util.extensions.getFileName
 import chat.rocket.android.util.extensions.getMimeType
+import com.bumptech.glide.load.resource.gif.GifDrawable
 import com.bumptech.glide.request.target.SimpleTarget
 import com.bumptech.glide.request.transition.Transition
 
@@ -21,22 +22,32 @@ fun ChatRoomFragment.showFileAttachmentDialog(uri: Uri) {
             description.text.clear()
             when {
                 mimeType.startsWith("image") -> {
-                    GlideApp
-                        .with(context)
-                        .asBitmap()
-                        .load(uri)
-                        .override(imagePreview.width, imagePreview.height)
-                        .fitCenter()
-                        .into(object : SimpleTarget<Bitmap>() {
-                            override fun onResourceReady(
-                                resource: Bitmap,
-                                transition: Transition<in Bitmap>?
-                            ) {
-                                bitmap = resource
-                                imagePreview.setImageBitmap(resource)
-                                imagePreview.isVisible = true
-                            }
-                        })
+                    if (mimeType.contains("gif")) {
+                        GlideApp
+                            .with(context)
+                            .asGif()
+                            .load(uri)
+                            .override(imagePreview.width, imagePreview.height)
+                            .fitCenter()
+                            .into(imagePreview)
+                    } else {
+                        GlideApp
+                            .with(context)
+                            .asBitmap()
+                            .load(uri)
+                            .override(imagePreview.width, imagePreview.height)
+                            .fitCenter()
+                            .into(object : SimpleTarget<Bitmap>() {
+                                override fun onResourceReady(
+                                    resource: Bitmap,
+                                    transition: Transition<in Bitmap>?
+                                ) {
+                                    bitmap = resource
+                                    imagePreview.setImageBitmap(resource)
+                                }
+                            })
+                    }
+                    imagePreview.isVisible = true
                 }
                 mimeType.startsWith("video") -> audioVideoAttachment.isVisible = true
                 else -> {


### PR DESCRIPTION
Closes https://github.com/RocketChat/Rocket.Chat.Android/issues/1744

It will also render the gif on the upload file dialog as expected:

![ezgif-2-cfc7a9479af4](https://user-images.githubusercontent.com/11776825/47310954-5bdd5f00-d5ed-11e8-8d56-a9a111c96509.gif)
