### PR TITLE
[FIX] roomid or username required bug

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomPresenter.kt
@@ -172,11 +172,13 @@ class ChatRoomPresenter @Inject constructor(
     }
 
     private suspend fun subscribeRoomChanges() {
-        chatRoomId?.let {
-            manager.addRoomChannel(it, roomChangesChannel)
-            for (room in roomChangesChannel) {
-                dbManager.getRoom(room.id)?.let {
-                    view.onRoomUpdated(roomMapper.map(chatRoom = it, showLastMessage = true))
+        withContext(CommonPool + strategy.jobs) {
+            chatRoomId?.let {
+                manager.addRoomChannel(it, roomChangesChannel)
+                for (room in roomChangesChannel) {
+                    dbManager.getRoom(room.id)?.let {
+                        view.onRoomUpdated(roomMapper.map(chatRoom = it, showLastMessage = true))
+                    }
                 }
             }
         }

--- a/app/src/main/java/chat/rocket/android/userdetails/presentation/UserDetailsPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/userdetails/presentation/UserDetailsPresenter.kt
@@ -39,37 +39,7 @@ class UserDetailsPresenter @Inject constructor(
                     val openedChatRooms = chatRoomByName(name = u.name)
                     val avatarUrl = u.username?.let { currentServer.avatarUrl(avatar = it) }
 
-                    val chatRoom: ChatRoom? = if (openedChatRooms.isEmpty()) {
-                        ChatRoom(
-                            id = "",
-                            type = roomTypeOf(RoomType.DIRECT_MESSAGE),
-                            name = u.username ?: u.name.orEmpty(),
-                            fullName = u.name,
-                            favorite = false,
-                            open = false,
-                            alert = false,
-                            status = userStatusOf(u.status),
-                            client = client,
-                            broadcast = false,
-                            archived = false,
-                            default = false,
-                            description = null,
-                            groupMentions = null,
-                            userMentions = null,
-                            lastMessage = null,
-                            lastSeen = null,
-                            topic = null,
-                            announcement = null,
-                            roles = null,
-                            unread = 0,
-                            readonly = false,
-                            muted = null,
-                            subscriptionId = "",
-                            timestamp = null,
-                            updatedAt = null,
-                            user = null
-                        )
-                    } else openedChatRooms.firstOrNull()
+                    val chatRoom: ChatRoom? = openedChatRooms.firstOrNull()
 
                     view.showUserDetails(
                         avatarUrl = avatarUrl,

--- a/app/src/main/java/chat/rocket/android/userdetails/presentation/UserDetailsPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/userdetails/presentation/UserDetailsPresenter.kt
@@ -1,5 +1,6 @@
 package chat.rocket.android.userdetails.presentation
 
+import chat.rocket.android.chatrooms.domain.FetchChatRoomsInteractor
 import chat.rocket.android.core.lifecycle.CancelStrategy
 import chat.rocket.android.db.DatabaseManager
 import chat.rocket.android.server.domain.GetConnectingServerInteractor
@@ -27,6 +28,7 @@ class UserDetailsPresenter @Inject constructor(
     private var currentServer = serverInteractor.get()!!
     private val manager = factory.create(currentServer)
     private val client = manager.client
+    private val interactor = FetchChatRoomsInteractor(client,dbManager)
 
     fun loadUserDetails(userId: String) {
         launchUI(strategy) {
@@ -61,6 +63,8 @@ class UserDetailsPresenter @Inject constructor(
             val result = retryIO("createDirectMessage($id") {
                 client.createDirectMessage(username = id)
             }
+
+            interactor.refreshChatRooms()
 
             val userEntity = withContext(CommonPool) {
                 dbManager.userDao().getUser(id = id)


### PR DESCRIPTION
@RocketChat/android

Closes #1912 

chatRoom object was instantiated with empty id. So, toDirectMessage() was called with empty id in clickListeners.

Works fine now.