### PR TITLE
[IMPROVEMENT] Avoid closing the app from some screens.

### DIFF
--- a/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
+++ b/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
@@ -100,18 +100,18 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
     }
 
     override fun onBackPressed() {
-        if (drawer_layout.isDrawerOpen(GravityCompat.START))
+        if (drawer_layout.isDrawerOpen(GravityCompat.START)) {
             closeDrawer()
-        else
+        } else {
             supportFragmentManager.findFragmentById(R.id.fragment_container)?.let {
-                if (it !is ChatRoomsFragment && supportFragmentManager.backStackEntryCount==0) {
+                if (it !is ChatRoomsFragment && supportFragmentManager.backStackEntryCount == 0) {
                     presenter.toChatList(chatRoomId)
                     setCheckedNavDrawerItem(R.id.menu_action_chats)
-                }
-                else{
+                } else {
                     super.onBackPressed()
                 }
             }
+        }
     }
 
     override fun activityInjector(): AndroidInjector<Activity> = activityDispatchingAndroidInjector

--- a/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
+++ b/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import chat.rocket.android.BuildConfig
 import chat.rocket.android.R
+import chat.rocket.android.chatrooms.ui.ChatRoomsFragment
 import chat.rocket.android.main.adapter.AccountsAdapter
 import chat.rocket.android.main.adapter.Selector
 import chat.rocket.android.main.presentation.MainPresenter
@@ -96,6 +97,21 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
         if (isFinishing) {
             presenter.disconnect()
         }
+    }
+
+    override fun onBackPressed() {
+        if (drawer_layout.isDrawerOpen(GravityCompat.START))
+            closeDrawer()
+        else
+            supportFragmentManager.findFragmentById(R.id.fragment_container)?.let {
+                if (it !is ChatRoomsFragment && supportFragmentManager.backStackEntryCount==0) {
+                    presenter.toChatList(chatRoomId)
+                    setCheckedNavDrawerItem(R.id.menu_action_chats)
+                }
+                else{
+                    super.onBackPressed()
+                }
+            }
     }
 
     override fun activityInjector(): AndroidInjector<Activity> = activityDispatchingAndroidInjector


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

Closes #1995 

#### Changes: Uses method `onBackPressed()` to exit the app only from `ChatRoomsFragment`.