### PR TITLE
[WIP] Pjl issue 968 (has glitch so not ready to be reviewed or merged)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,8 @@
             android:configChanges="orientation"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:launchMode="singleInstance">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -45,6 +46,11 @@
                 <data
                     android:host="go.rocket.chat"
                     android:path="/auth"
+                    android:scheme="https" />
+
+                <data
+                    android:host="viasatconnect.com"
+                    android:path="/_oauth/viasatsso"
                     android:scheme="https" />
             </intent-filter>
         </activity>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,11 +47,6 @@
                     android:host="go.rocket.chat"
                     android:path="/auth"
                     android:scheme="https" />
-
-                <data
-                    android:host="viasatconnect.com"
-                    android:path="/_oauth/viasatsso"
-                    android:scheme="https" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/chat/rocket/android/authentication/domain/model/OauthDeepLinkInfo.kt
+++ b/app/src/main/java/chat/rocket/android/authentication/domain/model/OauthDeepLinkInfo.kt
@@ -1,0 +1,53 @@
+package chat.rocket.android.authentication.domain.model
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import androidx.core.net.toUri
+import android.os.Parcelable
+import chat.rocket.android.util.extensions.decodeUrl
+import chat.rocket.android.util.extensions.toJsonObject
+import kotlinx.android.parcel.Parcelize
+import timber.log.Timber
+
+private const val JSON_CREDENTIAL_TOKEN = "credentialToken"
+private const val JSON_CREDENTIAL_SECRET = "credentialSecret"
+private const val OAUTH_STATE = "state"
+
+@SuppressLint("ParcelCreator")
+@Parcelize
+data class OauthDeepLinkInfo(
+        val state: String,
+        val credentialToken: String,
+        val credentialSecret: String
+) : Parcelable
+
+fun Intent.getOauthDeepLinkInfo(): OauthDeepLinkInfo? {
+    val uri = data
+    return if (action == Intent.ACTION_VIEW && uri != null && isOauthDeepLink(uri.toString())) {
+        val jsonResult = uri
+                .toString()
+                .decodeUrl()
+                .substringAfter("#")
+                .toJsonObject()
+        val credentialToken = jsonResult.optString(JSON_CREDENTIAL_TOKEN)
+        val credentialSecret = jsonResult.optString(JSON_CREDENTIAL_SECRET)
+        val oauthState = uri
+                .toString()
+                .substringBefore("#")
+                .toUri()
+                .getQueryParameter(OAUTH_STATE)
+        try {
+            OauthDeepLinkInfo(oauthState, credentialToken, credentialSecret)
+        } catch (ex: Exception) {
+            Timber.d(ex, "Error parsing oauth deeplink")
+            null
+        }
+    } else null
+}
+
+private fun isOauthDeepLink(uri: String): Boolean {
+    if (uri.contains(JSON_CREDENTIAL_TOKEN) && uri.contains(JSON_CREDENTIAL_SECRET)) {
+        return true
+    }
+    return false
+}

--- a/app/src/main/java/chat/rocket/android/authentication/loginoptions/ui/LoginOptionsFragment.kt
+++ b/app/src/main/java/chat/rocket/android/authentication/loginoptions/ui/LoginOptionsFragment.kt
@@ -492,7 +492,9 @@ class LoginOptionsFragment : Fragment(), LoginOptionsView {
         requestCode: Int
     ) {
         if (Constants.OAUTH_WITH_CHROME_CUSTOM_TAB && REQUEST_CODE_FOR_OAUTH == requestCode) {
-            view?.openTabbedUrl(accountUrl)
+            button.setOnClickListener {
+                view?.openTabbedUrl(accountUrl)
+            }
         } else {
             ui { activity ->
                 button.setOnClickListener {

--- a/app/src/main/java/chat/rocket/android/authentication/ui/AuthenticationActivity.kt
+++ b/app/src/main/java/chat/rocket/android/authentication/ui/AuthenticationActivity.kt
@@ -9,8 +9,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import chat.rocket.android.R
 import chat.rocket.android.analytics.event.ScreenViewEvent
+import chat.rocket.android.authentication.loginoptions.ui.LoginOptionsFragment
 import chat.rocket.android.authentication.domain.model.LoginDeepLinkInfo
 import chat.rocket.android.authentication.domain.model.getLoginDeepLinkInfo
+import chat.rocket.android.authentication.domain.model.getOauthDeepLinkInfo
+import chat.rocket.android.authentication.domain.model.OauthDeepLinkInfo
 import chat.rocket.android.authentication.presentation.AuthenticationPresenter
 import chat.rocket.android.util.extensions.addFragment
 import chat.rocket.common.util.ifNull
@@ -33,6 +36,15 @@ class AuthenticationActivity : AppCompatActivity(), HasSupportFragmentInjector {
         setContentView(R.layout.activity_authentication)
         setupToolbar()
         loadCredentials()
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        intent?.getOauthDeepLinkInfo()?.let{
+            showLoginOptionsFragment(it)
+        } .ifNull {
+            loadCredentials()
+        }
     }
 
     private fun setupToolbar() {
@@ -99,6 +111,14 @@ class AuthenticationActivity : AppCompatActivity(), HasSupportFragmentInjector {
         ) {
             chat.rocket.android.authentication.server.ui.newInstance()
         }
+    }
+
+    private fun showLoginOptionsFragment(oauthDeepLinkInfo: OauthDeepLinkInfo) {
+        val fragment = supportFragmentManager.findFragmentByTag(ScreenViewEvent.LoginOptions.screenName) as LoginOptionsFragment
+        supportFragmentManager.beginTransaction()
+                .replace(R.id.fragment_container, fragment, ScreenViewEvent.LoginOptions.screenName)
+                .commit()
+        fragment.handleOauthResponse(oauthDeepLinkInfo)
     }
 
     private fun showChatList() = presenter.toChatList()

--- a/app/src/main/java/chat/rocket/android/helper/Constants.kt
+++ b/app/src/main/java/chat/rocket/android/helper/Constants.kt
@@ -10,6 +10,8 @@ object Constants {
     const val CHATROOM_PRIVATE_GROUP = 1
     const val CHATROOM_DM = 2
     const val CHATROOM_LIVE_CHAT = 3
+
+    const val OAUTH_WITH_CHROME_CUSTOM_TAB = true
 }
 
 object ChatRoomsSortOrder {


### PR DESCRIPTION
@RocketChat/android

Partially Addresses #968 but contains a critical glitch that can be seen in the gif below. Essentially the user has to manually go to the menu and choose "open in chrome" for the deep link to fire that brings the user back into Rocket.chat.

<img src='https://user-images.githubusercontent.com/4001792/51558174-d1ef9d00-1e4c-11e9-9aea-07b3a63c9940.gif' width=250>

The reason for the above glitch is that Chrome Custom Tabs require a custom scheme (rocketchat://auth) for deep links to work. Hence, the deep link doesn't fire until after I choose "open in chrome". This will not work for users as they will not know to do that and it adds a cumbersome extra step.

The only solution for this that I can think of is to modify the HTML/JS that are sent back to the Chrome Custom Tab by the Rocket.chat server after it has completed the Oauth negotiation with the Oauth server. The following code (code formatting not working so you may need to read it in edit view) is sent back to the Chrome Custom Tab by the Rocket.chat server after Oauth negotation completes:

`<body>
<p id="completedText" style="display:none;">
Login completed. <a href="#" id="loginCompleted">
 Click here</a> to close this window.
</p>
<div id="config" style="display:none;">{"setCredentialToken":true,"credentialToken":"Nv2z5j0TscHYgA4RjXrn7N3N1Gf4TpP1eyNYUlEu","credentialSecret":"En7nstczQ0Ocwuz0PLlil5-sil_GOsn9i0yx21B1GaJ","storagePrefix":"Meteor.oauth.credentialSecret-","isCordova":true}</div>
<script type="text/javascript" src="/packages/oauth/end_of_popup_response.js"></script>
</body>
`

If this code were to redirect the Chrome Custom tab to a URL starting with "rocketchat://auth" then the deep link would fire and the user could complete the logging in using Oauth2 and Chrome Custom Tab.