### PR TITLE
[I18n] Fix typo in Russian language file

### DIFF
--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -332,7 +332,7 @@
     <string name="message_room_changed_privacy">Тип канала изменен на: %1$s пользователем %2$s</string>
 
     <!-- User Details -->
-    <string name="timezone">Часовой поясe</string>
+    <string name="timezone">Часовой пояс</string>
 
     <!-- Report -->
     <string name="submit">Отправить</string>


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

#### Changes: 

Removed trailing `e`.

#### Screenshots or GIF for the change:

![untitled](https://user-images.githubusercontent.com/944459/52217454-bea2ef80-2898-11e9-9220-fc9787bd6cfb.png)