### PR TITLE
[NEW] Add eraser feature and fix selecting black color in drawing.

### DIFF
--- a/draw/src/main/java/chat/rocket/android/draw/main/ui/DrawActivity.kt
+++ b/draw/src/main/java/chat/rocket/android/draw/main/ui/DrawActivity.kt
@@ -54,8 +54,17 @@ class DrawingActivity : DaggerAppCompatActivity(), DrawView {
 
     private fun setupDrawTools() {
         image_draw_eraser.setOnClickListener {
+            custom_draw_view.setEraser(true)
+            custom_draw_view.setColor(
+                    ResourcesCompat.getColor(resources, R.color.color_white, null)
+            )
+            toggleDrawTools(draw_tools, false)
+        }
+
+        image_draw_eraser.setOnLongClickListener {
             custom_draw_view.clearCanvas()
             toggleDrawTools(draw_tools, false)
+            true
         }
 
         image_draw_width.setOnClickListener {
@@ -111,7 +120,16 @@ class DrawingActivity : DaggerAppCompatActivity(), DrawView {
     }
 
     private fun colorSelector() {
+        image_color_black.setOnClickListener {
+            custom_draw_view.setEraser(false)
+            custom_draw_view.setColor(
+                    ResourcesCompat.getColor(resources, R.color.color_black, null)
+            )
+            scaleColorView(image_color_black)
+        }
+
         image_color_red.setOnClickListener {
+            custom_draw_view.setEraser(false)
             custom_draw_view.setColor(
                 ResourcesCompat.getColor(resources, R.color.color_red, null)
             )
@@ -119,6 +137,7 @@ class DrawingActivity : DaggerAppCompatActivity(), DrawView {
         }
 
         image_color_yellow.setOnClickListener {
+            custom_draw_view.setEraser(false)
             custom_draw_view.setColor(
                 ResourcesCompat.getColor(
                     resources,
@@ -129,6 +148,7 @@ class DrawingActivity : DaggerAppCompatActivity(), DrawView {
         }
 
         image_color_green.setOnClickListener {
+            custom_draw_view.setEraser(false)
             custom_draw_view.setColor(
                 ResourcesCompat.getColor(
                     resources,
@@ -139,6 +159,7 @@ class DrawingActivity : DaggerAppCompatActivity(), DrawView {
         }
 
         image_color_blue.setOnClickListener {
+            custom_draw_view.setEraser(false)
             custom_draw_view.setColor(
                 ResourcesCompat.getColor(resources, R.color.color_blue, null)
             )
@@ -146,6 +167,7 @@ class DrawingActivity : DaggerAppCompatActivity(), DrawView {
         }
 
         image_color_pink.setOnClickListener {
+            custom_draw_view.setEraser(false)
             custom_draw_view.setColor(
                 ResourcesCompat.getColor(
                     resources,
@@ -156,6 +178,7 @@ class DrawingActivity : DaggerAppCompatActivity(), DrawView {
         }
 
         image_color_brown.setOnClickListener {
+            custom_draw_view.setEraser(false)
             custom_draw_view.setColor(
                 ResourcesCompat.getColor(
                     resources,

--- a/draw/src/main/java/chat/rocket/android/draw/widget/CustomDrawView.kt
+++ b/draw/src/main/java/chat/rocket/android/draw/widget/CustomDrawView.kt
@@ -27,6 +27,7 @@ class CustomDrawView(context: Context, attrs: AttributeSet) : View(context, attr
     private var mStartY = 0f
     private var mIsSaving = false
     private var mIsStrokeWidthBarEnabled = false
+    private var mIsEraserEnabled = false
 
     init {
         mPaint.apply {
@@ -71,8 +72,13 @@ class CustomDrawView(context: Context, attrs: AttributeSet) : View(context, attr
     }
 
     fun setColor(newColor: Int) {
+        val alpha = if(!mIsEraserEnabled) {
+            mPaintOptions.alpha
+        }else {
+            255
+        }
         @ColorInt
-        val alphaColor = ColorUtils.setAlphaComponent(newColor, mPaintOptions.alpha)
+        val alphaColor = ColorUtils.setAlphaComponent(newColor, alpha)
         mPaintOptions.color = alphaColor
         if (mIsStrokeWidthBarEnabled) {
             invalidate()
@@ -83,6 +89,10 @@ class CustomDrawView(context: Context, attrs: AttributeSet) : View(context, attr
         val alpha = (newAlpha*255)/100
         mPaintOptions.alpha = alpha
         setColor(mPaintOptions.color)
+    }
+
+    fun setEraser(value: Boolean){
+        mIsEraserEnabled = value
     }
 
     fun setStrokeWidth(newStrokeWidth: Float) {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes  #1938 #2021 

#### Changes:
Added eraser feature which erases canvas on click.
Clears whole canvas on Long clicking the eraser widget
Made alpha value constant so that eraser won't become transparent on changing alpha value.
Made black color selectable in color palette.
#### Screenshots or GIF for the change:
![eraset](https://user-images.githubusercontent.com/25877454/52222506-aac3b180-28c9-11e9-847f-0cf05cb55062.gif)
![red](https://user-images.githubusercontent.com/25877454/52222550-c333cc00-28c9-11e9-84ff-741becd3d754.gif)


