### PR TITLE
Fix margin to EditText inside DeleteAccoutDialog

### DIFF
--- a/app/src/main/java/chat/rocket/android/profile/ui/ProfileFragment.kt
+++ b/app/src/main/java/chat/rocket/android/profile/ui/ProfileFragment.kt
@@ -1,6 +1,7 @@
 package chat.rocket.android.profile.ui
 
 import DrawableHelper
+import android.annotation.SuppressLint
 import android.app.Activity
 import androidx.appcompat.app.AlertDialog
 import android.content.Intent
@@ -292,6 +293,7 @@ class ProfileFragment : Fragment(), ProfileView, ActionMode.Callback {
         }
     }
 
+    @SuppressLint("RestrictedApi")
     fun showDeleteAccountDialog() {
         val passwordEditText = EditText(context)
         passwordEditText.hint = getString(R.string.msg_password)
@@ -299,7 +301,7 @@ class ProfileFragment : Fragment(), ProfileView, ActionMode.Callback {
         context?.let {
             val builder = AlertDialog.Builder(it)
             builder.setTitle(R.string.title_are_you_sure)
-                .setView(passwordEditText)
+                .setView(passwordEditText, 60, 30, 60, 0)
                 .setPositiveButton(R.string.action_delete_account) { _, _ ->
                     presenter.deleteAccount(passwordEditText.text.toString())
                 }


### PR DESCRIPTION
Signed-off-by: Arthur Diniz <arthurbdiniz@gmail.com>

@RocketChat/android

Closes #2043 

#### Changes:  Add left and right margin of `60` and top margin of `30`

#### Screenshots or GIF for the change:
![screenshot_20190228-150458_rocketchat](https://user-images.githubusercontent.com/18387694/53588679-46b0a800-3b6c-11e9-8a91-b4d367992819.jpg)
