### PR TITLE
Fix about fragment title on rotate

### DIFF
--- a/app/src/main/java/chat/rocket/android/about/ui/AboutFragment.kt
+++ b/app/src/main/java/chat/rocket/android/about/ui/AboutFragment.kt
@@ -40,6 +40,11 @@ class AboutFragment : Fragment() {
         analyticsManager.logScreenView(ScreenViewEvent.About)
     }
 
+    override fun onResume() {
+        super.onResume()
+        setupToolbar()
+    }
+
     private fun setupViews() {
         text_version_name.text = BuildConfig.VERSION_NAME
         text_build_number.text = getString(


### PR DESCRIPTION
Signed-off-by: Arthur Diniz <arthurbdiniz@gmail.com>

@RocketChat/android

Closes #2063 

#### Changes: Add on manifest the property config changes that handle the rotation setup

#### Screenshots or GIF for the change:
![20190228_172929](https://user-images.githubusercontent.com/18387694/53596517-aca62b00-3b7e-11e9-9077-3ad018fc81d2.gif)

