### PR TITLE
[FIX] Clear notifications after opening the app

### DIFF
--- a/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
+++ b/app/src/main/java/chat/rocket/android/main/ui/MainActivity.kt
@@ -38,6 +38,9 @@ import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.app_bar.*
 import kotlinx.android.synthetic.main.nav_header.view.*
 import javax.inject.Inject
+import android.app.NotificationManager
+import android.content.Context
+
 
 private const val CURRENT_STATE = "current_state"
 
@@ -90,6 +93,9 @@ class MainActivity : AppCompatActivity(), MainView, HasActivityInjector,
             presenter.toChatList(chatRoomId)
             isFragmentAdded = true
         }
+        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE)
+                as NotificationManager
+        notificationManager.cancelAll()
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #2052 

#### Changes: clear all notifications with Notification manager in onResume of MainActivity

#### Screenshots or GIF for the change:
