### PR TITLE
[FIX] App bar title changes when rotating the screen.

### DIFF
--- a/app/src/main/java/chat/rocket/android/preferences/ui/PreferencesFragment.kt
+++ b/app/src/main/java/chat/rocket/android/preferences/ui/PreferencesFragment.kt
@@ -45,6 +45,11 @@ class PreferencesFragment : Fragment(), PreferencesView {
         analyticsManager.logScreenView(ScreenViewEvent.Preferences)
     }
 
+    override fun onResume() {
+        setupToolbar()
+        super.onResume()
+    }
+
     override fun setupAnalyticsTrackingView(isAnalyticsTrackingEnabled: Boolean) {
         if (BuildConfig.FLAVOR == "foss") {
             switch_analytics_tracking.isChecked = false

--- a/app/src/main/java/chat/rocket/android/preferences/ui/PreferencesFragment.kt
+++ b/app/src/main/java/chat/rocket/android/preferences/ui/PreferencesFragment.kt
@@ -38,7 +38,6 @@ class PreferencesFragment : Fragment(), PreferencesView {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setupToolbar()
         setupListeners()
         presenter.loadAnalyticsTrackingInformation()
 


### PR DESCRIPTION
Signed-off-by: Arthur Diniz <arthurbdiniz@gmail.com>

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #2104 

#### Changes: Just add on resume method to set the title when the activity wakes up

#### Screenshots or GIF for the change:
![](https://user-images.githubusercontent.com/18387694/53924101-7de5f400-4059-11e9-9542-6ca5d7ad89e2.jpg)

