### PR TITLE
Fix Drawing activity not opening after giving write permission

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomActivity.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomActivity.kt
@@ -3,11 +3,13 @@ package chat.rocket.android.chatroom.ui
 import DrawableHelper
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.appcompat.app.AppCompatActivity
 import chat.rocket.android.R
 import chat.rocket.android.chatroom.presentation.ChatRoomNavigator
+import chat.rocket.android.helper.AndroidPermissionsHelper
 import chat.rocket.android.server.domain.GetCurrentServerInteractor
 import chat.rocket.android.server.infraestructure.ConnectionManagerFactory
 import chat.rocket.android.util.extensions.addFragment
@@ -166,5 +168,17 @@ class ChatRoomActivity : AppCompatActivity(), HasSupportFragmentInjector {
     private fun finishActivity() {
         super.onBackPressed()
         overridePendingTransition(R.anim.close_enter, R.anim.close_exit)
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int,
+                                            permissions: Array<String>, grantResults: IntArray) {
+        when (requestCode) {
+            AndroidPermissionsHelper.WRITE_EXTERNAL_STORAGE_CODE -> {
+                if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
+                    supportFragmentManager.findFragmentByTag(TAG_CHAT_ROOM_FRAGMENT)?.onRequestPermissionsResult(requestCode,permissions,grantResults)
+                }
+                return
+            }
+        }
     }
 }

--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
@@ -6,6 +6,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Bundle
@@ -27,6 +28,7 @@ import androidx.core.content.FileProvider
 import androidx.core.text.bold
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -66,6 +68,7 @@ import chat.rocket.android.helper.EndlessRecyclerViewScrollListener
 import chat.rocket.android.helper.ImageHelper
 import chat.rocket.android.helper.KeyboardHelper
 import chat.rocket.android.helper.MessageParser
+import chat.rocket.android.helper.AndroidPermissionsHelper
 import chat.rocket.android.util.extension.asObservable
 import chat.rocket.android.util.extension.createImageFile
 import chat.rocket.android.util.extensions.circularRevealOrUnreveal
@@ -903,14 +906,29 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardListener, EmojiR
                     if (!ImageHelper.canWriteToExternalStorage(fragmentActivity)) {
                         ImageHelper.checkWritingPermission(fragmentActivity)
                     } else {
-                        val intent = Intent(fragmentActivity, DrawingActivity::class.java)
-                        startActivityForResult(intent, REQUEST_CODE_FOR_DRAW)
+                        startDrawingActivity(fragmentActivity)
                     }
                 }
 
                 handler.postDelayed({
                     hideAttachmentOptions()
                 }, 400)
+            }
+        }
+    }
+
+    private fun startDrawingActivity(fragmentActivity : FragmentActivity) {
+        val intent = Intent(fragmentActivity, DrawingActivity::class.java)
+        startActivityForResult(intent, REQUEST_CODE_FOR_DRAW)
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+        when (requestCode) {
+            AndroidPermissionsHelper.WRITE_EXTERNAL_STORAGE_CODE -> {
+                if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
+                    activity?.let { fragmentactivity -> startDrawingActivity(fragmentactivity) }
+                }
+                return
             }
         }
     }


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #2143 

#### Changes:
added onRequestPermissionResult to check whether permission is granted or not and making intent to open drawing activity on allowing permission.
#### Screenshots or GIF for the change:
![videotogif_2019 03 16_17 27 05](https://user-images.githubusercontent.com/25877454/54475002-162a6880-4812-11e9-9667-ed247a5bef70.gif)

