### PR TITLE
Fixed Typo in DrawableHelper.kt

### DIFF
--- a/app/src/main/java/chat/rocket/android/app/DrawableHelper.kt
+++ b/app/src/main/java/chat/rocket/android/app/DrawableHelper.kt
@@ -43,7 +43,7 @@ object DrawableHelper {
     /**
      * Tints an array of Drawable.
      *
-     * REMARK: you MUST always wrap the array of Drawable before tint it.
+     * REMARK: you MUST always wrap the array of Drawable before tinting it.
      *
      * @param drawables The array of Drawable to tint.
      * @param context The context.


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

#### Changes:
Corrected typo 'before tint it' to 'before tinting it'.

#### Screenshots or GIF for the change:

![1 error7 - drawablehelper kt](https://user-images.githubusercontent.com/30703644/55734706-79866f80-5a39-11e9-99ab-af8eac826465.PNG)