### PR TITLE
[FIX] Migrate JitsiMeet api and fix build errors

### DIFF
--- a/app/src/main/java/chat/rocket/android/videoconference/ui/VideoConferenceActivity.kt
+++ b/app/src/main/java/chat/rocket/android/videoconference/ui/VideoConferenceActivity.kt
@@ -3,11 +3,11 @@ package chat.rocket.android.videoconference.ui
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.core.os.bundleOf
 import chat.rocket.android.videoconference.presenter.JitsiVideoConferenceView
 import chat.rocket.android.videoconference.presenter.VideoConferencePresenter
 import dagger.android.AndroidInjection
 import org.jitsi.meet.sdk.JitsiMeetActivity
+import org.jitsi.meet.sdk.JitsiMeetConferenceOptions
 import org.jitsi.meet.sdk.JitsiMeetView
 import org.jitsi.meet.sdk.JitsiMeetViewListener
 import timber.log.Timber
@@ -52,34 +52,22 @@ class VideoConferenceActivity : JitsiMeetActivity(), JitsiVideoConferenceView,
     override fun onConferenceJoined(map: MutableMap<String, Any>?) =
         logJitsiMeetViewState("Joined video conferencing", map)
 
-    override fun onConferenceWillLeave(map: MutableMap<String, Any>?) =
-        logJitsiMeetViewState("Leaving video conferencing", map)
-
-    override fun onConferenceLeft(map: MutableMap<String, Any>?) {
-        logJitsiMeetViewState("Left video conferencing", map)
-        finishJitsiVideoConference()
+    // Currently JitsiMeet api does not support onConferenceWillLeave, onConferenceLeft,
+    // onLoadConfigError, and onConferenceFailed methods. We should use onConferenceTerminated
+    // method instead.
+    override fun onConferenceTerminated(map: MutableMap<String, Any>?) {
+        logJitsiMeetViewState("Video conference terminated", map)
     }
 
-    override fun onLoadConfigError(map: MutableMap<String, Any>?) =
-        logJitsiMeetViewState("Error loading video conference config", map)
-
-    override fun onConferenceFailed(map: MutableMap<String, Any>?) =
-        logJitsiMeetViewState("Video conference failed", map)
-
     override fun startJitsiVideoConference(url: String, name: String?) {
-        view?.loadURLObject(
-            bundleOf(
-                "config" to bundleOf(
-                    "startWithAudioMuted" to true,
-                    "startWithVideoMuted" to true
-                ),
-                "context" to bundleOf(
-                    "user" to bundleOf("name" to name),
-                    "iss" to "rocketchat-android"
-                ),
-                "url" to url
-            )
-        )
+        // Currently JitsiMeetConferenceOptions does not support context bundle field.
+        // We cannot set "user" and "iss" any more.
+        view?.join(
+                JitsiMeetConferenceOptions.Builder()
+                        .setAudioMuted(true)
+                        .setVideoMuted(true)
+                        .setRoom(url)
+                        .build())
     }
 
     override fun finishJitsiVideoConference() {


### PR DESCRIPTION
JitsiMeet changed their api recently, it caused our build errors. We
need to migrate our code to use their latest apis to fix build errors.

@RocketChat/android 
Hi, this is Runzhi, do you guys have time to review my code, it fixed the critical build error in our codebase.

