### PR TITLE
[IMPROVEMENT] Changes status title

### DIFF
--- a/app/src/main/res/layout/fragment_user_details.xml
+++ b/app/src/main/res/layout/fragment_user_details.xml
@@ -95,7 +95,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/screen_edge_left_and_right_margins"
             android:layout_marginTop="20dp"
-            android:text="@string/status"
+            android:text="@string/user_detail_status"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/text_message" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -360,6 +360,7 @@ https://github.com/RocketChat/java-code-styles/blob/master/CODING_STYLE.md#strin
     <!-- User Details -->
     <string name="timezone">Timezone</string>
     <string name="status" translatable="false">Status: %1$s</string>
+    <string name="user_detail_status" translatable="false">Status</string>
 
     <!-- Report -->
     <string name="submit">Submit</string>


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

#### Changes:
 Currently `profilefragment`, `Userdetailsfragment` are using `status` string which is formattable but `Userdetailsfragment` does not require any formatting for the status string so created a new string `user_detail_status`.

#### Screenshots or GIF for the change:
Before:
![Screenshot_2019-04-20-00-06-22-074_chat rocket android dev](https://user-images.githubusercontent.com/25877454/56438686-6b6e0400-6301-11e9-8d0b-8444fc80254f.png)
After:
![Screenshot_2019-04-20-00-11-14-871_chat rocket android dev](https://user-images.githubusercontent.com/25877454/56438697-75900280-6301-11e9-9447-cd868be4d2ae.png)



