### PR TITLE
[NEW] Implemented Tall configurable size WebView for Rich Messages

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatroom/adapter/ChatRoomAdapter.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/adapter/ChatRoomAdapter.kt
@@ -214,7 +214,14 @@ class ChatRoomAdapter(
             val temp = action as ButtonAction
             if (temp.url != null && temp.isWebView != null) {
                 if (temp.isWebView == true) {
-                    //TODO: Open in a configurable sizable webview
+                    //Open in a configurable sizable webview
+                    if(temp.webViewHeightRatio == "tall"){
+                        temp.url?.let {
+                            if(roomId != null){
+                                actionSelectListener?.openTallWebview(roomId, it)
+                            }
+                        }
+                    }
                     Timber.d("Open in a configurable sizable webview")
                 } else {
                     //Open in chrome custom tab
@@ -334,5 +341,7 @@ class ChatRoomAdapter(
         fun copyPermalink(id: String)
 
         fun reportMessage(id: String)
+
+        fun openTallWebview(roomId: String, url: String)
     }
 }

--- a/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomNavigator.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomNavigator.kt
@@ -6,6 +6,7 @@ import chat.rocket.android.R
 import chat.rocket.android.chatdetails.ui.TAG_CHAT_DETAILS_FRAGMENT
 import chat.rocket.android.chatinformation.ui.messageInformationIntent
 import chat.rocket.android.chatroom.ui.ChatRoomActivity
+import chat.rocket.android.chatroom.ui.bottomsheet.WebUrlBottomSheet
 import chat.rocket.android.chatroom.ui.chatRoomIntent
 import chat.rocket.android.favoritemessages.ui.TAG_FAVORITE_MESSAGES_FRAGMENT
 import chat.rocket.android.files.ui.TAG_FILES_FRAGMENT
@@ -152,5 +153,10 @@ class ChatRoomNavigator(internal val activity: ChatRoomActivity) {
     fun toMessageInformation(messageId: String) {
         activity.startActivity(activity.messageInformationIntent(messageId = messageId))
         activity.overridePendingTransition(R.anim.open_enter, R.anim.open_exit)
+    }
+
+    fun toTallWebview(roomId: String, url: String) {
+        val weburlbottomsheet = WebUrlBottomSheet.newInstance(url, roomId,"full")
+        weburlbottomsheet.show(activity.supportFragmentManager,null)
     }
 }

--- a/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomPresenter.kt
@@ -1290,4 +1290,10 @@ class ChatRoomPresenter @Inject constructor(
     fun getDraftUnfinishedMessage(): String? {
         return localRepository.get(draftKey)
     }
+
+    fun openTallWebview(roomId: String, url: String) {
+        launchUI(strategy){
+            navigator.toTallWebview(roomId, url)
+        }
+    }
 }

--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
@@ -1183,6 +1183,10 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardListener, EmojiR
         }
     }
 
+    override fun openTallWebview(roomId: String, url: String) {
+        presenter.openTallWebview(roomId, url)
+    }
+
     override fun copyPermalink(id: String) {
         presenter.copyPermalink(id)
     }

--- a/app/src/main/java/chat/rocket/android/chatroom/ui/bottomsheet/WebUrlBottomSheet.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/bottomsheet/WebUrlBottomSheet.kt
@@ -1,0 +1,105 @@
+package chat.rocket.android.chatroom.ui.bottomsheet
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.FrameLayout
+import chat.rocket.android.R
+import chat.rocket.android.util.extensions.ui
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import kotlinx.android.synthetic.main.app_bar.*
+import kotlinx.android.synthetic.main.webview_bottomsheet.*
+
+private const val BUNDLE_WEB_PAGE_URL = "web_page_url"
+private const val BUNDLE_CHATROOM_ID = "chatroom_id"
+private const val BUNDLE_BOTTOMSHEET_STATE = "bottomsheet_state"
+
+class WebUrlBottomSheet : BottomSheetDialogFragment() {
+
+    private lateinit var webPageUrl: String
+    private lateinit var chatRoomId: String
+    private lateinit var bottomsheetState: String
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        arguments?.run {
+            webPageUrl = getString(BUNDLE_WEB_PAGE_URL, "")
+            chatRoomId = getString(BUNDLE_CHATROOM_ID, "")
+            bottomsheetState = getString(BUNDLE_BOTTOMSHEET_STATE, "")
+        } ?: requireNotNull(arguments) { "no arguments supplied when the fragment was instantiated" }
+        return inflater.inflate(R.layout.webview_bottomsheet, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        setupToolbar()
+        setupWebView()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        var bottomsheet: FrameLayout = dialog.findViewById(com.google.android.material.R.id.design_bottom_sheet)
+        var behaviour = BottomSheetBehavior.from(bottomsheet)
+        behaviour.setBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
+            override fun onSlide(p0: View, p1: Float) {
+            }
+
+            override fun onStateChanged(p0: View, newState: Int) {
+                if (newState == BottomSheetBehavior.STATE_HIDDEN) {
+                    dialog.cancel()
+                }
+                if (newState == BottomSheetBehavior.STATE_DRAGGING) {
+                    behaviour.state = BottomSheetBehavior.STATE_COLLAPSED
+                }
+            }
+
+        })
+        if (bottomsheetState == "tall"){
+            bottomsheet.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
+            behaviour.state = BottomSheetBehavior.STATE_COLLAPSED
+            behaviour.isHideable = false
+        }
+    }
+
+    private fun setupToolbar() {
+        toolbar.title = webPageUrl.replace("https://","")
+        toolbar.setNavigationIcon(R.drawable.ic_close_white_24dp)
+        toolbar.setNavigationOnClickListener {
+            dialog.cancel()
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        setupWebView()
+    }
+
+    private fun setupWebView() {
+        with(web_view.settings) {
+            javaScriptEnabled = true
+            domStorageEnabled = true
+        }
+
+        web_view.webViewClient = object : WebViewClient() {
+            override fun onPageFinished(view: WebView, url: String) {
+                super.onPageFinished(view, url)
+                ui {
+                    view_loading.hide()
+                }
+            }
+        }
+        web_view.loadUrl(webPageUrl)
+    }
+
+    companion object {
+        fun newInstance(webPageUrl: String, chatRoomId: String, bottomsheetState: String) = WebUrlBottomSheet().apply {
+            arguments = Bundle(3).apply {
+                putString(BUNDLE_WEB_PAGE_URL, webPageUrl)
+                putString(BUNDLE_CHATROOM_ID, chatRoomId)
+                putString(BUNDLE_BOTTOMSHEET_STATE, bottomsheetState)
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/webview_bottomsheet.xml
+++ b/app/src/main/res/layout/webview_bottomsheet.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="android.support.design.widget.BottomSheetBehavior">
+
+    <include
+        android:id="@+id/layout_app_bar"
+        layout="@layout/app_bar" />
+
+    <WebView
+        android:id="@+id/web_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@+id/layout_app_bar"
+        />
+
+    <com.wang.avi.AVLoadingIndicatorView
+        android:id="@+id/view_loading"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        app:indicatorColor="@color/colorBlack"
+        app:indicatorName="BallPulseIndicator" />
+
+</RelativeLayout>


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

#### Changes:
 Implemented `Bottomsheet ` which displays webview for tall `webviewHeightRatio`. Bottomsheet covers half of the screen and is not draggable by user.


#### Screenshots or GIF for the change:
![videotogif_2019 04 20_18 46 40](https://user-images.githubusercontent.com/25877454/56457767-0667ec00-639d-11e9-91a5-f60647e845ae.gif)
