### PR TITLE
[FIX] Can't install dev and release on the same device

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -115,7 +115,7 @@
 
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="chat.rocket.android.fileprovider"
+            android:authorities=".fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data


### PR DESCRIPTION
Was conflicting Fileprovider's authorities.

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/android

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
#### Issue: 
Failed to commit install session 700417465 with command cmd package install-commit 700417465. Error: INSTALL_FAILED_CONFLICTING_PROVIDER: Package couldn't be installed in /data/app/chat.rocket.android.dev-NIX0violFlkc0WZmKcI6CQ==: Can't install because provider name chat.rocket.android.fileprovider (in package chat.rocket.android.dev) is already used by chat.rocket.android