### PR TITLE
[FIX] Fixes compound drawables being set to the incorrect direction in RTL languages

### DIFF
--- a/app/src/main/java/chat/rocket/android/app/DrawableHelper.kt
+++ b/app/src/main/java/chat/rocket/android/app/DrawableHelper.kt
@@ -73,13 +73,13 @@ object DrawableHelper {
         DrawableCompat.setTint(drawable, ContextCompat.getColor(context, resId))
 
     /**
-     * Compounds an array of Drawable (to appear to the left of the text) into an array of TextView.
+     * Compounds an array of Drawable (to appear on the start side of a text) into an array of TextView.
      *
-     * REMARK: the number of elements in both array of Drawable and TextView MUST be equal.
+     * REMARK: the number of elements in both arrays of Drawable and TextView MUST be equal.
      *
      * @param textView The array of TextView.
      * @param drawables The array of Drawable.
-     * @see compoundLeftDrawable
+     * @see compoundStartDrawable
      */
     fun compoundDrawables(textView: Array<TextView>, drawables: Array<Drawable>) {
         if (textView.size != drawables.size) {
@@ -96,13 +96,13 @@ object DrawableHelper {
     }
 
     /**
-     * Compounds a Drawable (to appear on the left side of a text) into a TextView.
+     * Compounds a Drawable (to appear on the start side of a text) into a TextView.
      *
      * @param textView The TextView.
      * @param drawable The Drawable.
      * @see compoundDrawables
      */
-    fun compoundLeftDrawable(textView: TextView, drawable: Drawable) =
+    fun compoundStartDrawable(textView: TextView, drawable: Drawable) =
         if (textView.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_LTR) {
             textView.setCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null)
         } else {
@@ -110,13 +110,13 @@ object DrawableHelper {
         }
 
     /**
-     * Compounds a Drawable (to appear on the right side of a text) into a TextView.
+     * Compounds a Drawable (to appear on the end side of a text) into a TextView.
      *
      * @param textView The TextView.
      * @param drawable The Drawable.
-     * @see compoundLeftDrawable
+     * @see compoundStartDrawable
      */
-    fun compoundRightDrawable(textView: TextView, drawable: Drawable) =
+    fun compoundEndDrawable(textView: TextView, drawable: Drawable) =
         if (textView.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_LTR) {
             textView.setCompoundDrawablesWithIntrinsicBounds(null, null, drawable, null)
         } else {
@@ -124,22 +124,22 @@ object DrawableHelper {
         }
 
     /**
-     * Compounds a Drawable (to appear on the left and right side of a text) into a TextView.
+     * Compounds a Drawable (to appear on the start and end side of a text) into a TextView.
      *
      * @param textView The TextView.
-     * @param leftDrawable The left Drawable.
-     * @param rightDrawable The right Drawable.
-     * @see compoundLeftDrawable
+     * @param startDrawable The start Drawable.
+     * @param endDrawable The end Drawable.
+     * @see compoundStartDrawable
      */
-    fun compoundLeftAndRightDrawable(
+    fun compoundStartAndEndDrawable(
         textView: TextView,
-        leftDrawable: Drawable,
-        rightDrawable: Drawable
+        startDrawable: Drawable,
+        endDrawable: Drawable
     ) =
         if (textView.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_LTR) {
-            textView.setCompoundDrawablesWithIntrinsicBounds(leftDrawable, null, rightDrawable, null)
+            textView.setCompoundDrawablesWithIntrinsicBounds(startDrawable, null, endDrawable, null)
         } else {
-            textView.setCompoundDrawablesWithIntrinsicBounds(rightDrawable, null, leftDrawable, null)
+            textView.setCompoundDrawablesWithIntrinsicBounds(endDrawable, null, startDrawable, null)
         }
 
     /**

--- a/app/src/main/java/chat/rocket/android/app/DrawableHelper.kt
+++ b/app/src/main/java/chat/rocket/android/app/DrawableHelper.kt
@@ -1,5 +1,6 @@
 import android.content.Context
 import android.graphics.drawable.Drawable
+import android.view.View
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
@@ -60,7 +61,7 @@ object DrawableHelper {
     /**
      * Tints a Drawable.
      *
-     * REMARK: you MUST always wrap the Drawable before tint it.
+     * REMARK: you MUST always wrap the Drawable before tinting it.
      *
      * @param drawable The Drawable to tint.
      * @param context The context.
@@ -74,7 +75,7 @@ object DrawableHelper {
     /**
      * Compounds an array of Drawable (to appear to the left of the text) into an array of TextView.
      *
-     * REMARK: the number of elements in both array of Drawable and EditText MUST be equal.
+     * REMARK: the number of elements in both array of Drawable and TextView MUST be equal.
      *
      * @param textView The array of TextView.
      * @param drawables The array of Drawable.
@@ -85,7 +86,11 @@ object DrawableHelper {
             return
         } else {
             for (i in textView.indices) {
-                textView[i].setCompoundDrawablesWithIntrinsicBounds(drawables[i], null, null, null)
+                if (textView[i].resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_LTR) {
+                    textView[i].setCompoundDrawablesWithIntrinsicBounds(drawables[i], null, null, null)
+                } else {
+                    textView[i].setCompoundDrawablesWithIntrinsicBounds(null, null, drawables[i], null)
+                }
             }
         }
     }
@@ -98,7 +103,11 @@ object DrawableHelper {
      * @see compoundDrawables
      */
     fun compoundLeftDrawable(textView: TextView, drawable: Drawable) =
-        textView.setCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null)
+        if (textView.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_LTR) {
+            textView.setCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null)
+        } else {
+            textView.setCompoundDrawablesWithIntrinsicBounds(null, null, drawable, null)
+        }
 
     /**
      * Compounds a Drawable (to appear on the right side of a text) into a TextView.
@@ -108,7 +117,11 @@ object DrawableHelper {
      * @see compoundLeftDrawable
      */
     fun compoundRightDrawable(textView: TextView, drawable: Drawable) =
-        textView.setCompoundDrawablesWithIntrinsicBounds(null, null, drawable, null)
+        if (textView.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_LTR) {
+            textView.setCompoundDrawablesWithIntrinsicBounds(null, null, drawable, null)
+        } else {
+            textView.setCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null)
+        }
 
     /**
      * Compounds a Drawable (to appear on the left and right side of a text) into a TextView.
@@ -123,7 +136,11 @@ object DrawableHelper {
         leftDrawable: Drawable,
         rightDrawable: Drawable
     ) =
-        textView.setCompoundDrawablesWithIntrinsicBounds(leftDrawable, null, rightDrawable, null)
+        if (textView.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_LTR) {
+            textView.setCompoundDrawablesWithIntrinsicBounds(leftDrawable, null, rightDrawable, null)
+        } else {
+            textView.setCompoundDrawablesWithIntrinsicBounds(rightDrawable, null, leftDrawable, null)
+        }
 
     /**
      * Returns the user status drawable.

--- a/app/src/main/java/chat/rocket/android/authentication/registerusername/ui/RegisterUsernameFragment.kt
+++ b/app/src/main/java/chat/rocket/android/authentication/registerusername/ui/RegisterUsernameFragment.kt
@@ -140,7 +140,7 @@ class RegisterUsernameFragment : Fragment(), RegisterUsernameView {
             val atDrawable = DrawableHelper.getDrawableFromId(R.drawable.ic_at_black_20dp, it)
             DrawableHelper.wrapDrawable(atDrawable)
             DrawableHelper.tintDrawable(atDrawable, it, R.color.colorDrawableTintGrey)
-            DrawableHelper.compoundLeftDrawable(text_username, atDrawable)
+            DrawableHelper.compoundStartDrawable(text_username, atDrawable)
         }
     }
 

--- a/app/src/main/java/chat/rocket/android/chatdetails/ui/ChatDetailsFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatdetails/ui/ChatDetailsFragment.kt
@@ -195,7 +195,7 @@ class ChatDetailsFragment : Fragment(), ChatDetailsView {
             val wrappedDrawable = DrawableHelper.wrapDrawable(it)
             val mutableDrawable = wrappedDrawable.mutate()
             DrawableHelper.tintDrawable(mutableDrawable, context!!, R.color.colorPrimary)
-            DrawableHelper.compoundLeftDrawable(name, mutableDrawable)
+            DrawableHelper.compoundStartDrawable(name, mutableDrawable)
         }
     }
 

--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomActivity.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomActivity.kt
@@ -139,7 +139,7 @@ class ChatRoomActivity : AppCompatActivity(), HasSupportFragmentInjector {
     }
 
     fun setupExpandMoreForToolbar(listener: (View) -> Unit) {
-        DrawableHelper.compoundRightDrawable(
+        DrawableHelper.compoundEndDrawable(
             text_toolbar_title,
             DrawableHelper.getDrawableFromId(R.drawable.ic_chatroom_toolbar_expand_more_20dp, this)
         )

--- a/app/src/main/java/chat/rocket/android/directory/ui/DirectoryFragment.kt
+++ b/app/src/main/java/chat/rocket/android/directory/ui/DirectoryFragment.kt
@@ -233,14 +233,14 @@ class DirectoryFragment : Fragment(), DirectoryView {
     private fun updateSortByTitle() {
         if (isSortByChannels) {
             text_sort_by.text = getString(R.string.msg_channels)
-            DrawableHelper.compoundLeftAndRightDrawable(
+            DrawableHelper.compoundStartAndEndDrawable(
                 text_sort_by,
                 hashtagDrawable,
                 arrowDownDrawable
             )
         } else {
             text_sort_by.text = getString(R.string.msg_users)
-            DrawableHelper.compoundLeftAndRightDrawable(
+            DrawableHelper.compoundStartAndEndDrawable(
                 text_sort_by,
                 userDrawable,
                 arrowDownDrawable

--- a/app/src/main/java/chat/rocket/android/directory/ui/DirectorySortingBottomSheetFragment.kt
+++ b/app/src/main/java/chat/rocket/android/directory/ui/DirectorySortingBottomSheetFragment.kt
@@ -100,21 +100,21 @@ class DirectorySortingBottomSheetFragment : BottomSheetDialogFragment() {
         }
     }
 
-    private fun checkSelection(textView: TextView, leftDrawable: Drawable) {
+    private fun checkSelection(textView: TextView, startDrawable: Drawable) {
         context?.let {
-            DrawableHelper.compoundLeftAndRightDrawable(
+            DrawableHelper.compoundStartAndEndDrawable(
                 textView,
-                leftDrawable,
+                startDrawable,
                 checkDrawable
             )
         }
     }
 
-    private fun uncheckSelection(textView: TextView, leftDrawable: Drawable) {
+    private fun uncheckSelection(textView: TextView, startDrawable: Drawable) {
         context?.let {
-            DrawableHelper.compoundLeftDrawable(
+            DrawableHelper.compoundStartDrawable(
                 textView,
-                leftDrawable
+                startDrawable
             )
         }
     }

--- a/app/src/main/java/chat/rocket/android/sortingandgrouping/ui/SortingAndGroupingBottomSheetFragment.kt
+++ b/app/src/main/java/chat/rocket/android/sortingandgrouping/ui/SortingAndGroupingBottomSheetFragment.kt
@@ -143,21 +143,21 @@ class SortingAndGroupingBottomSheetFragment : BottomSheetDialogFragment(), Sorti
         text_sort_by.text = getString(R.string.msg_sort_by_placeholder, text.toLowerCase())
     }
 
-    private fun checkSelection(textView: TextView, @DrawableRes leftDrawable: Int) {
+    private fun checkSelection(textView: TextView, @DrawableRes startDrawable: Int) {
         context?.let {
-            DrawableHelper.compoundLeftAndRightDrawable(
+            DrawableHelper.compoundStartAndEndDrawable(
                 textView,
-                DrawableHelper.getDrawableFromId(leftDrawable, it),
+                DrawableHelper.getDrawableFromId(startDrawable, it),
                 DrawableHelper.getDrawableFromId(R.drawable.ic_check, it)
             )
         }
     }
 
-    private fun uncheckSelection(textView: TextView, @DrawableRes leftDrawable: Int) {
+    private fun uncheckSelection(textView: TextView, @DrawableRes startDrawable: Int) {
         context?.let {
-            DrawableHelper.compoundLeftDrawable(
+            DrawableHelper.compoundStartDrawable(
                 textView,
-                DrawableHelper.getDrawableFromId(leftDrawable, it)
+                DrawableHelper.getDrawableFromId(startDrawable, it)
             )
         }
     }


### PR DESCRIPTION
@RocketChat/android

Closes #2285

#### Changes:

TextView compound drawables are now set to the appropriate direction according to the applied locale direction in the context configuration.

#### Screenshots or GIF for the change:

![Sorting options](https://user-images.githubusercontent.com/20887574/57169369-87e06500-6e06-11e9-9369-415fe8beb01f.gif)