### PR TITLE
[FIX][IMPROVEMENT][I18N] Adds support for RTL ViewPager for RTL languages

### DIFF
--- a/app/src/main/java/chat/rocket/android/app/DrawableHelper.kt
+++ b/app/src/main/java/chat/rocket/android/app/DrawableHelper.kt
@@ -86,10 +86,10 @@ object DrawableHelper {
             return
         } else {
             for (i in textView.indices) {
-                if (textView[i].resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_LTR) {
-                    textView[i].setCompoundDrawablesWithIntrinsicBounds(drawables[i], null, null, null)
-                } else {
+                if (textView[i].resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL) {
                     textView[i].setCompoundDrawablesWithIntrinsicBounds(null, null, drawables[i], null)
+                } else {
+                    textView[i].setCompoundDrawablesWithIntrinsicBounds(drawables[i], null, null, null)
                 }
             }
         }
@@ -103,10 +103,10 @@ object DrawableHelper {
      * @see compoundDrawables
      */
     fun compoundStartDrawable(textView: TextView, drawable: Drawable) =
-        if (textView.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_LTR) {
-            textView.setCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null)
-        } else {
+        if (textView.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL) {
             textView.setCompoundDrawablesWithIntrinsicBounds(null, null, drawable, null)
+        } else {
+            textView.setCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null)
         }
 
     /**
@@ -117,10 +117,10 @@ object DrawableHelper {
      * @see compoundStartDrawable
      */
     fun compoundEndDrawable(textView: TextView, drawable: Drawable) =
-        if (textView.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_LTR) {
-            textView.setCompoundDrawablesWithIntrinsicBounds(null, null, drawable, null)
-        } else {
+        if (textView.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL) {
             textView.setCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null)
+        } else {
+            textView.setCompoundDrawablesWithIntrinsicBounds(null, null, drawable, null)
         }
 
     /**
@@ -136,10 +136,10 @@ object DrawableHelper {
         startDrawable: Drawable,
         endDrawable: Drawable
     ) =
-        if (textView.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_LTR) {
-            textView.setCompoundDrawablesWithIntrinsicBounds(startDrawable, null, endDrawable, null)
-        } else {
+        if (textView.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL) {
             textView.setCompoundDrawablesWithIntrinsicBounds(endDrawable, null, startDrawable, null)
+        } else {
+            textView.setCompoundDrawablesWithIntrinsicBounds(startDrawable, null, endDrawable, null)
         }
 
     /**

--- a/app/src/main/res/drawable/ic_send_24dp.xml
+++ b/app/src/main/res/drawable/ic_send_24dp.xml
@@ -1,12 +1,12 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
+    android:autoMirrored="true"
     android:viewportHeight="20.0"
     android:viewportWidth="22.0">
 
     <path
         android:fillColor="#FF1D74F5"
-        android:fillType="nonZero"
         android:pathData="M0.869,1.32C0.731,0.987 0.79,0.565 1.045,0.276C1.281,0.01 1.634,-0.079 1.967,0.076L20.645,9.134C20.939,9.29 21.136,9.645 21.136,10C21.155,10.377 20.939,10.71 20.645,10.866L1.967,19.924C1.634,20.079 1.281,19.99 1.045,19.724C0.79,19.435 0.712,19.036 0.869,18.68L4.263,10L0.869,1.32ZM18.193,10L3.262,2.741L5.832,9.29L9.953,9.334C10.404,9.312 10.777,9.734 10.777,10.266C10.796,10.777 10.423,11.199 9.953,11.199L5.636,11.199L3.262,17.259L18.193,10Z" />
 
 </vector>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -70,6 +70,9 @@
     <string name="msg_app_version">الإصدار: %1$s (%2$d)</string>
     <string name="msg_server_version">إصدار الخادم: %1$s</string>
     <string name="msg_send_analytics">إرسال التحليلات</string>
+    <string name="msg_send_analytics_tracking">إرسال تحليلات لمساعدة تطوير البرنامج</string>
+    <string name="msg_do_not_send_analytics_tracking">لا يتم إرسال تحليلات لمساعدة تطوير البرنامج</string>
+    <string name="msg_not_applicable_since_it_is_a_foss_version">لا يمكن لأنه إصدار FOSS</string>
     <string name="msg_logout_from_rocket_chat">تسجيل الخروج من Rocket.Chat</string>
     <string name="msg_delete_account">حذف الحساب</string>
     <string name="msg_change_status">تغيير الوضع</string>
@@ -94,7 +97,7 @@
     </string-array>
 
     <!-- Regular information messages -->
-    <string name="msg_generic_error">نأسف حدث خطأ ما حاول مرة أخرى</string>
+    <string name="msg_generic_error">نأسف حدث خطأ ما، حاول مرة أخرى</string>
     <string name="msg_no_data_to_display">لا يوجد بيانات للعرض</string>
     <string name="msg_check_this_out">تحقق من هذا</string>
     <string name="msg_share_using">نشر بواسطة</string>
@@ -153,7 +156,7 @@
     <string name="msg_no_chat_title">لا توجد رسائل</string>
     <string name="msg_no_chat_description">إبدأ المحادثة لترى الرسائل هنا</string>
     <string name="msg_http_insecure">أنت تستخدم HTTP وهو غير آمن ونحن لا نحبذ ذلك.</string>
-    <string name="msg_error_checking_server_version">حدذ خطأ عند محاولة الوصول نسخة خادمك حاول مرة أخرى</string>
+    <string name="msg_error_checking_server_version">حدث خطأ أثناء التحقق من إصدار الخادم الخاص بك، حاول مرة أخرى</string>
     <string name="msg_invalid_server_protocol">النظام المستخدم غير مقبول، حاول ب HTTPS</string>
     <string name="msg_image_saved_successfully">تم حفظ الصورة في المعرض</string>
     <string name="msg_image_saved_failed">لم يتم حفظ الصورة</string>
@@ -189,12 +192,12 @@
     <string name="msg_unable_to_update_password">لا يمكن تحديث كلمة السر خطأ: %1$s</string>
     <string name="msg_password_updated_successfully">تم تحديث كلمة السر</string>
     <plurals name="msg_reacted_with_">
-        <item quantity="one">%1$s تفاعل مع %2$s</item>
-        <item quantity="other">%1$s تفاعل مع %2$s</item>
-        <item quantity="many">%1$s تفاعلوا مع %2$s</item>
-        <item quantity="zero">%1$s تفاعل مع %2$s</item>
-        <item quantity="few">%1$s تفاعلوا مع %2$s</item>
-        <item quantity="two">%1$s تفاعلا مع %2$s</item>
+        <item quantity="one">%1$s تفاعل ب %2$s</item>
+        <item quantity="other">%1$s تفاعل ب %2$s</item>
+        <item quantity="many">%1$s تفاعلوا ب %2$s</item>
+        <item quantity="zero">%1$s تفاعل ب %2$s</item>
+        <item quantity="few">%1$s تفاعلوا ب %2$s</item>
+        <item quantity="two">%1$s تفاعلا ب %2$s</item>
     </plurals>
     <string name="msg_credentials_saved_successfully">تم حفظ البيانات بنجاح</string>
     <string name="msg_camera_permission_denied">هناك حاجة إلى إذن الكاميرا لفتحها.</string>
@@ -206,8 +209,8 @@
     <!-- Create channel messages -->
     <string name="msg_private_channel">خاص</string>
     <string name="msg_public_channel">عام</string>
-    <string name="msg_private_channel_description">أنت فقط والأشخاص المدعوون يمكنكم دخزل هذه القناة</string>
-    <string name="msg_public_channel_description">الجميع يمكنه دخول هذه المجموعة</string>
+    <string name="msg_private_channel_description">أنت فقط والأشخاص المدعوون يمكنكم دخول هذه القناة</string>
+    <string name="msg_public_channel_description">يمكن للجميع دخول هذه القناة</string>
     <string name="msg_ready_only_channel">قناة للقراءة فقط</string>
     <string name="msg_ready_only_channel_description">المدير فقط يمكنه الكتابة</string>
     <string name="msg_invite_members">دعوة عضو للقناة</string>
@@ -221,18 +224,12 @@
     <string name="msg_view_less">رؤية أقل</string>
     <string name="msg_muted_on_this_channel">لقد جعلت هذه القناة صامتة</string>
 
-    <!-- Preferences messages -->
-    <string name="msg_analytics_tracking">تتبع التحليلات</string>
-    <string name="msg_send_analytics_tracking">إرسال تحليل لمساعدة تطوير البرنامج</string>
-    <string name="msg_do_not_send_analytics_tracking">لا يتم إرسال تحليل لمساعدة تطوير البرنامج</string>
-    <string name="msg_not_applicable_since_it_is_a_foss_version">لا يمكن لأنه إصدار FOSS</string>
-
     <!-- System messages -->
     <string name="message_room_name_changed">تم تغيير اسم الغرفة ل: %1$s بواسطة %2$s</string>
     <string name="message_user_added_by">المستخدم %1$s أضيف بواسطة %2$s</string>
     <string name="message_user_removed_by">المستخدم %1$s حذف بواسطة %2$s</string>
     <string name="message_user_left">غادر القناة.</string>
-    <string name="message_user_joined_channel">إنضم للقناة</string>
+    <string name="message_user_joined_channel">انضم للقناة</string>
     <string name="message_welcome">أهلا %s</string>
     <string name="message_removed">تم حذف الرسالة</string>
     <string name="message_pinned">تعلق رسالة:</string>
@@ -347,7 +344,7 @@
     <string name="header_favorite">المفضلات</string>
     <string name="msg_channels">القنوات</string>
     <string name="msg_users">المستخدمين</string>
-    <string name="msg_search_for_global_users">البحث عن المستخدمين العالميين</string>
+    <string name="msg_search_for_global_users">البحث عن المستخدمين عالميا</string>
     <string name="msg_search_for_global_users_description">إذا قمت بالتشغيل، يمكنك البحث عن أي مستخدم من شركات أو خوادم أخرى.</string>
     <string name="header_private_groups">المجموعات الخاصة</string>
     <string name="header_direct_messages">الرسائل المباشرة</string>
@@ -357,7 +354,7 @@
     <!-- Notifications -->
     <string name="share_label">تعديل الرسالة المنشورة</string>
     <string name="notif_action_reply_hint">رد</string>
-    <string name="notif_error_sending">فشل الرد حاول مرة أخرى</string>
+    <string name="notif_error_sending">فشل الرد، حاول مرة أخرى</string>
     <string name="notif_success_sending">تم إرسال الرسالة ل %1$s!</string>
     <string name="read_by">تمت القراءة بواسطة</string>
     <string name="message_information_title">معلومات الرسالة</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -114,7 +114,7 @@
     <string name="msg_reset">إعادة تعيين</string>
     <string name="msg_check_your_email_to_reset_your_password">تم إرسال الإيميل راجع إيميلك لتحديث كلمة السر</string>
     <string name="msg_invalid_email">من فضلك أدخل عنوان بريد صحيح</string>
-    <string name="msg_new_user_agreement">بالاستمرار أنت توافق على \n%1$s و %2$s</string>
+    <string name="msg_new_user_agreement">بالاستمرار أنت توافق على\n%1$s و %2$s</string>
     <string name="msg_yesterday">أمس</string>
     <string name="msg_today">اليوم</string>
     <string name="msg_message">رسالة</string>
@@ -209,7 +209,7 @@
     <!-- Create channel messages -->
     <string name="msg_private_channel">خاص</string>
     <string name="msg_public_channel">عام</string>
-    <string name="msg_private_channel_description">أنت فقط والأشخاص المدعوون يمكنكم دخول هذه القناة</string>
+    <string name="msg_private_channel_description">أنت والأشخاص المدعوون فقط يمكنكم دخول هذه القناة</string>
     <string name="msg_public_channel_description">يمكن للجميع دخول هذه القناة</string>
     <string name="msg_ready_only_channel">قناة للقراءة فقط</string>
     <string name="msg_ready_only_channel_description">المدير فقط يمكنه الكتابة</string>
@@ -270,17 +270,17 @@
 
     <!-- Mentions -->
     <string name="msg_mentions">إشارات</string>
-    <string name="msg_no_mention">لا إشارة</string>
-    <string name="msg_all_the_mentions_appear_here">الإشارات \nتظهر هنا</string>
+    <string name="msg_no_mention">لا يوجد إشارة</string>
+    <string name="msg_all_the_mentions_appear_here">الإشارات\nتظهر هنا</string>
 
     <!-- Pinned Messages -->
-    <string name="title_pinned_messages">رسالة مميزة</string>
-    <string name="no_pinned_messages">رسائل غير مميزة</string>
+    <string name="title_pinned_messages">الرسائل المميزة</string>
+    <string name="no_pinned_messages">لا يوجد رسائل مميزة</string>
     <string name="no_pinned_description">الرسائل المميزة\nتظهر هنا</string>
 
     <!-- Favorite Messages -->
     <string name="title_favorite_messages">الرسائل المفضلة</string>
-    <string name="no_favorite_messages">الرسائل غير المفضلة</string>
+    <string name="no_favorite_messages">لا يوجد رسائل مفضلة</string>
     <string name="no_favorite_description">الرسائل المفضلة\nتظهر هنا</string>
 
     <!-- Files -->
@@ -293,12 +293,12 @@
     <string name="max_file_size_exceeded">تجاوز حجم الملف %1$d بايت الحد الأقصى لحجم التحميل وهو %2$d بايت</string>
 
     <!-- Socket status -->
-    <string name="status_connected">اتصال</string>
-    <string name="status_disconnected">قطع الاتصال</string>
+    <string name="status_connected">متصل</string>
+    <string name="status_disconnected">غير متصل</string>
     <string name="status_connecting">يتم الاتصال</string>
-    <string name="status_authenticating">المصادقة</string>
+    <string name="status_authenticating">يتم المصادقة</string>
     <string name="status_disconnecting">يتم قطع الاتصال</string>
-    <string name="status_waiting">متصل في %d ثانية</string>
+    <string name="status_waiting">يتم الاتصال في %d ثانية</string>
 
     <!-- Suggestions -->
     <string name="suggest_all_description">تنبيه كل من في الغرفة</string>
@@ -312,9 +312,9 @@
     <string name="Slash_TableUnflip_Description">عرض ┬─┬ ノ( ゜-゜ノ)</string>
     <string name="Create_A_New_Channel">إنشاء قناة جديدة</string>
     <string name="Show_the_keyboard_shortcut_list">عرض اختصارات الكيبورد</string>
-    <string name="Invite_user_to_join_channel_all_from">دعوة أعضاء [#channel] للانضمام لهذه المجموعة</string>
-    <string name="Invite_user_to_join_channel_all_to">دعوة أعضاء هذه المجموعة للانضمام ل [#channel]</string>
-    <string name="Archive">ارشيف</string>
+    <string name="Invite_user_to_join_channel_all_from">دعوة أعضاء [#channel] للانضمام لهذه القناة</string>
+    <string name="Invite_user_to_join_channel_all_to">دعوة أعضاء هذه القناة للانضمام ل [#channel]</string>
+    <string name="Archive">أرشيف</string>
     <string name="Remove_someone_from_room">إزالة شخص من الغرفة</string>
     <string name="Leave_the_current_channel">مغادرة القناة الحالية</string>
     <string name="Displays_action_text">عرض نص الاجراء</string>
@@ -348,7 +348,7 @@
     <string name="msg_search_for_global_users_description">إذا قمت بالتشغيل، يمكنك البحث عن أي مستخدم من شركات أو خوادم أخرى.</string>
     <string name="header_private_groups">المجموعات الخاصة</string>
     <string name="header_direct_messages">الرسائل المباشرة</string>
-    <string name="header_live_chats">محادثات حية</string>
+    <string name="header_live_chats">المحادثات الحية</string>
     <string name="header_unknown">غير معروف</string>
 
     <!-- Notifications -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -70,6 +70,9 @@
     <string name="msg_app_version">Version: %1$s (%2$d)</string>
     <string name="msg_server_version">Serverversion: %1$s</string>
     <string name="msg_send_analytics">Analysesaten senden</string>
+    <string name="msg_send_analytics_tracking">Anonyme Statistiken senden um diese App weiter zu verbessern</string>
+    <string name="msg_do_not_send_analytics_tracking">KEINE anonymen Statistiken senden um diese App weiter zu verbessern</string>
+    <string name="msg_not_applicable_since_it_is_a_foss_version">Nicht anwendbar, da es sich um eine FOSS version handelt</string>
     <string name="msg_logout_from_rocket_chat">Logout von Rocket.Chat</string>
     <string name="msg_delete_account">Konto löschen</string>
     <string name="msg_change_status">Status ändern</string>
@@ -218,13 +221,6 @@
     <string name="msg_permalink_copied">Permanenter Link kopiert</string>
     <string name="msg_send_email">E-Mail senden</string>
     <string name="msg_android_app_support">Android App-Unterstützung</string>
-
-    <!-- Preferences messages -->
-    <string name="msg_analytics_tracking">Daten für Analysezwecke</string>
-    <string name="msg_send_analytics_tracking">Anonyme Statistiken senden um diese App weiter zu verbessern</string>
-    <string name="msg_do_not_send_analytics_tracking">KEINE anonymen Statistiken senden um diese App weiter zu verbessern</string>
-    <string name="msg_not_applicable_since_it_is_a_foss_version">Nicht anwendbar, da es sich um eine FOSS version handelt</string>
-
 
     <!-- System messages -->
     <string name="message_room_name_changed">Raum Namen geändert zu: %1$s von %2$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -70,6 +70,9 @@
     <string name="msg_app_version">Version: %1$s (%2$d)</string> <!-- TODO Translate -->
     <string name="msg_server_version">Server version: %1$s</string> <!-- TODO Translate -->
     <string name="msg_send_analytics">Send analytics</string> <!-- TODO Translate -->
+    <string name="msg_send_analytics_tracking">Envía estadísticas anónimas para ayudar a mejorar esta aplicación</string>
+    <string name="msg_do_not_send_analytics_tracking">No envíe estadísticas anónimas para ayudar a mejorar esta aplicación</string>
+    <string name="msg_not_applicable_since_it_is_a_foss_version">No aplica ya que es una versión FOSS</string>
     <string name="msg_logout_from_rocket_chat">Logout from Rocket.Chat</string> <!-- TODO Translate -->
     <string name="msg_delete_account">Delete account</string> <!-- TODO Translate -->
     <string name="msg_change_status">Change status</string> <!-- TODO Translate -->
@@ -214,12 +217,6 @@
     <string name="msg_credentials_saved_successfully">Credenciales guardadas con éxito</string>
     <string name="msg_camera_permission_denied">Camera permission is needed to open camera.</string> <!-- TODO Add translation -->
     <string name="msg_storage_permission_denied">Storage permission is needed to open Drawing.</string> <!-- TODO Add translation -->
-
-    <!-- Preferences messages -->
-    <string name="msg_analytics_tracking">Seguimiento analítico</string>
-    <string name="msg_send_analytics_tracking">Envía estadísticas anónimas para ayudar a mejorar esta aplicación</string>
-    <string name="msg_do_not_send_analytics_tracking">No envíe estadísticas anónimas para ayudar a mejorar esta aplicación</string>
-    <string name="msg_not_applicable_since_it_is_a_foss_version">No aplica ya que es una versión FOSS</string>
 
     <!-- System messages -->
     <string name="message_room_name_changed">Nombre de la sala cambiado para: %1$s por %2$s</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -70,6 +70,9 @@
     <string name="msg_app_version">Version: %1$s (%2$d)</string> <!-- TODO Translate -->
     <string name="msg_server_version">Server version: %1$s</string> <!-- TODO Translate -->
     <string name="msg_send_analytics">Send analytics</string> <!-- TODO Translate -->
+    <string name="msg_send_analytics_tracking">برای بهبود این کاره آمار ناشناس بفرستید</string>
+    <string name="msg_do_not_send_analytics_tracking">برای بهبود این کاره آمار ناشناس نفرستید</string>
+    <string name="msg_not_applicable_since_it_is_a_foss_version">قابل اجرا نیست زیرا نسخه‌ی FOSS است</string>
     <string name="msg_logout_from_rocket_chat">Logout from Rocket.Chat</string> <!-- TODO Translate -->
     <string name="msg_delete_account">Delete account</string> <!-- TODO Translate -->
     <string name="msg_change_status">Change status</string> <!-- TODO Translate -->
@@ -219,12 +222,6 @@
     <string name="msg_view_more">مشاهده‌ی بیشتر</string>
     <string name="msg_view_less">مشاهده‌ی کمتر</string>
     <string name="msg_muted_on_this_channel">آیا این کانال را بی‌صدا کردید؟</string>
-
-    <!-- Preferences messages -->
-    <string name="msg_analytics_tracking">ردگیری تحلیلی</string>
-    <string name="msg_send_analytics_tracking">برای بهبود این کاره آمار ناشناس بفرستید</string>
-    <string name="msg_do_not_send_analytics_tracking">برای بهبود این کاره آمار ناشناس نفرستید</string>
-    <string name="msg_not_applicable_since_it_is_a_foss_version">قابل اجرا نیست زیرا نسخه‌ی FOSS است</string>
 
     <!-- System messages -->
     <string name="message_room_name_changed">Room name changed to: %1$s by %2$s</string> <!-- TODO Add translation -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -70,6 +70,9 @@
     <string name="msg_app_version">Version: %1$s (%2$d)</string> <!-- TODO Translate -->
     <string name="msg_server_version">Server version: %1$s</string> <!-- TODO Translate -->
     <string name="msg_send_analytics">Send analytics</string> <!-- TODO Translate -->
+    <string name="msg_send_analytics_tracking">Envoyer des statistiques anonymes pour aider à l\'amélioration de l\'application</string>
+    <string name="msg_do_not_send_analytics_tracking">Ne pas envoyer des statistiques anonymes pour aider à l\'amélioration de l\'application</string>
+    <string name="msg_not_applicable_since_it_is_a_foss_version">Ne s\'applique pas étant donné qu\'il s\'agit d\'une version FOSS</string>
     <string name="msg_logout_from_rocket_chat">Logout from Rocket.Chat</string> <!-- TODO Translate -->
     <string name="msg_delete_account">Delete account</string> <!-- TODO Translate -->
     <string name="msg_change_status">Change status</string> <!-- TODO Translate -->
@@ -217,12 +220,6 @@
     <string name="msg_member_already_added">Cet utilisateur est déjà sélectionné</string>
     <string name="msg_member_not_found">Membre non trouvé</string>
     <string name="msg_channel_created_successfully">Salon créé</string>
-
-    <!-- Preferences messages -->
-    <string name="msg_analytics_tracking">Pistage à des fins d\'analyses</string>
-    <string name="msg_send_analytics_tracking">Envoyer des statistiques anonymes pour aider à l\'amélioration de l\'application</string>
-    <string name="msg_do_not_send_analytics_tracking">Ne pas envoyer des statistiques anonymes pour aider à l\'amélioration de l\'application</string>
-    <string name="msg_not_applicable_since_it_is_a_foss_version">Ne s\'applique pas étant donné qu\'il s\'agit d\'une version FOSS</string>
 
     <!-- System messages -->
     <string name="message_room_name_changed">Le nom du salon %1$s a été changé en %2$s</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -70,6 +70,9 @@
     <string name="msg_app_version">Version: %1$s (%2$d)</string> <!-- TODO Translate -->
     <string name="msg_server_version">Server version: %1$s</string> <!-- TODO Translate -->
     <string name="msg_send_analytics">Send analytics</string> <!-- TODO Translate -->
+    <string name="msg_send_analytics_tracking">इस ऐप को बेहतर बनाने में मदद के लिए अज्ञात स्टेटिक्स भेजें</string>
+    <string name="msg_do_not_send_analytics_tracking">इस ऐप को बेहतर बनाने में मदद के लिए अनाम स्टेटिक न भेजें</string>
+    <string name="msg_not_applicable_since_it_is_a_foss_version">लागू नहीं है क्योंकि यह एक FOSS संस्करण है</string>
     <string name="msg_logout_from_rocket_chat">Logout from Rocket.Chat</string> <!-- TODO Translate -->
     <string name="msg_delete_account">Delete account</string> <!-- TODO Translate -->
     <string name="msg_change_status">Change status</string> <!-- TODO Translate -->
@@ -220,12 +223,6 @@
     <string name="msg_server">Server</string> <!-- TODO Translate -->
     <string name="msg_add_new_server">Add New Server</string>  <!-- TODO Translate -->
     <string name="msg_directory">Directory</string> <!-- TODO Translate -->
-
-    <!-- Preferences messages -->
-    <string name="msg_analytics_tracking">एनालिटिक्स ट्रैकिंग</string>
-    <string name="msg_send_analytics_tracking">इस ऐप को बेहतर बनाने में मदद के लिए अज्ञात स्टेटिक्स भेजें</string>
-    <string name="msg_do_not_send_analytics_tracking">इस ऐप को बेहतर बनाने में मदद के लिए अनाम स्टेटिक न भेजें</string>
-    <string name="msg_not_applicable_since_it_is_a_foss_version">लागू नहीं है क्योंकि यह एक FOSS संस्करण है</string>
 
     <!-- System messages -->
     <string name="message_room_name_changed">%2$s ने रूम का नाम बदलकर %1$s किया</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -70,6 +70,9 @@
     <string name="msg_app_version">Version: %1$s (%2$d)</string> <!-- TODO Translate -->
     <string name="msg_server_version">Server version: %1$s</string> <!-- TODO Translate -->
     <string name="msg_send_analytics">Send analytics</string> <!-- TODO Translate -->
+    <string name="msg_send_analytics_tracking">Invia statistiche anonime per migliorare questa app</string>
+    <string name="msg_do_not_send_analytics_tracking">Non inviare statiche anonime per migliorare questa app</string>
+    <string name="msg_not_applicable_since_it_is_a_foss_version">Non applicabile poiché è una versione FOSS</string>
     <string name="msg_logout_from_rocket_chat">Logout from Rocket.Chat</string> <!-- TODO Translate -->
     <string name="msg_delete_account">Delete account</string> <!-- TODO Translate -->
     <string name="msg_change_status">Change status</string> <!-- TODO Translate -->
@@ -216,12 +219,6 @@
     <string name="msg_view_more">vedere di più</string>
     <string name="msg_view_less">vedere di meno</string>
     <string name="msg_muted_on_this_channel">Sei disattivato su questo canale</string>
-
-    <!-- Preferences messages -->
-    <string name="msg_analytics_tracking">Tracciamento Analitico</string>
-    <string name="msg_send_analytics_tracking">Invia statistiche anonime per migliorare questa app</string>
-    <string name="msg_do_not_send_analytics_tracking">Non inviare statiche anonime per migliorare questa app</string>
-    <string name="msg_not_applicable_since_it_is_a_foss_version">Non applicabile poiché è una versione FOSS</string>
 
     <!-- System messages -->
     <string name="message_room_name_changed">Nome della camera cambiato in: %1$s da %2$s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -70,6 +70,9 @@
     <string name="msg_app_version">Version: %1$s (%2$d)</string> <!-- TODO Translate -->
     <string name="msg_server_version">Server version: %1$s</string> <!-- TODO Translate -->
     <string name="msg_send_analytics">Send analytics</string> <!-- TODO Translate -->
+    <string name="msg_send_analytics_tracking">アプリ改善のための匿名統計情報を送信する</string>
+    <string name="msg_do_not_send_analytics_tracking">アプリ改善のための匿名統計情報を送信しない</string>
+    <string name="msg_not_applicable_since_it_is_a_foss_version">FOSSバージョンのため、適用できません</string>
     <string name="msg_logout_from_rocket_chat">Logout from Rocket.Chat</string> <!-- TODO Translate -->
     <string name="msg_delete_account">Delete account</string> <!-- TODO Translate -->
     <string name="msg_change_status">Change status</string> <!-- TODO Translate -->
@@ -219,12 +222,6 @@
     <string name="msg_permalink_copied">パーマリンクのコピー</string>
     <string name="msg_send_email">Send email</string> <!-- TODO - Add proper translation -->
     <string name="msg_android_app_support">Android app support</string> <!-- TODO - Add proper translation -->
-
-    <!-- Preferences messages -->
-    <string name="msg_analytics_tracking">トラッキングの分析</string>
-    <string name="msg_send_analytics_tracking">アプリ改善のための匿名統計情報を送信する</string>
-    <string name="msg_do_not_send_analytics_tracking">アプリ改善のための匿名統計情報を送信しない</string>
-    <string name="msg_not_applicable_since_it_is_a_foss_version">FOSSバージョンのため、適用できません</string>
 
     <!-- System messages -->
     <string name="message_room_name_changed">ルーム名を %1$s から %2$s へ変更しました。</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -70,6 +70,9 @@
     <string name="msg_app_version">Version: %1$s (%2$d)</string> <!-- TODO Translate -->
     <string name="msg_server_version">Server version: %1$s</string> <!-- TODO Translate -->
     <string name="msg_send_analytics">Send analytics</string> <!-- TODO Translate -->
+    <string name="msg_send_analytics_tracking">Envie estatísticas anônimas para ajudar a melhorar este app</string>
+    <string name="msg_do_not_send_analytics_tracking">Não envie estatísticas anônimas para ajudar a melhorar este app</string>
+    <string name="msg_not_applicable_since_it_is_a_foss_version">Não aplicável devido a versão do aplicativo ser FOSS</string>
     <string name="msg_logout_from_rocket_chat">Logout from Rocket.Chat</string> <!-- TODO Translate -->
     <string name="msg_delete_account">Delete account</string> <!-- TODO Translate -->
     <string name="msg_change_status">Change status</string> <!-- TODO Translate -->
@@ -218,12 +221,6 @@
     <string name="msg_member_already_added">Você já selecionou este usuário</string>
     <string name="msg_member_not_found">Membro não encontrado</string>
     <string name="msg_channel_created_successfully">Chat criado com sucesso</string>
-
-    <!-- Preferences messages -->
-    <string name="msg_analytics_tracking">Rastreamento de análises</string>
-    <string name="msg_send_analytics_tracking">Envie estatísticas anônimas para ajudar a melhorar este app</string>
-    <string name="msg_do_not_send_analytics_tracking">Não envie estatísticas anônimas para ajudar a melhorar este app</string>
-    <string name="msg_not_applicable_since_it_is_a_foss_version">Não aplicável devido a versão do aplicativo ser FOSS</string>
 
     <!-- System messages -->
     <string name="message_room_name_changed">Nome da sala alterado para: %1$s por %2$s</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -70,6 +70,9 @@
     <string name="msg_app_version">Version: %1$s (%2$d)</string> <!-- TODO Translate -->
     <string name="msg_server_version">Server version: %1$s</string> <!-- TODO Translate -->
     <string name="msg_send_analytics">Send analytics</string> <!-- TODO Translate -->
+    <string name="msg_send_analytics_tracking">Enviar estatísticas anónimas para ajudar a melhorar esta aplicação</string>
+    <string name="msg_do_not_send_analytics_tracking">Não enviar estatísticas anónimas para ajudar a melhorar esta aplicação</string>
+    <string name="msg_not_applicable_since_it_is_a_foss_version">Não aplicável, visto ser uma versão FOSS</string>
     <string name="msg_logout_from_rocket_chat">Logout from Rocket.Chat</string> <!-- TODO Translate -->
     <string name="msg_delete_account">Delete account</string> <!-- TODO Translate -->
     <string name="msg_change_status">Change status</string> <!-- TODO Translate -->
@@ -218,12 +221,6 @@
     <string name="msg_view_more">mostrar mais</string>
     <string name="msg_view_less">mostrar menos</string>
     <string name="msg_muted_on_this_channel">Você está silenciado neste canal</string>
-
-    <!-- Preferences messages -->
-    <string name="msg_analytics_tracking">Acompanhamento de análise</string>
-    <string name="msg_send_analytics_tracking">Enviar estatísticas anónimas para ajudar a melhorar esta aplicação</string>
-    <string name="msg_do_not_send_analytics_tracking">Não enviar estatísticas anónimas para ajudar a melhorar esta aplicação</string>
-    <string name="msg_not_applicable_since_it_is_a_foss_version">Não aplicável, visto ser uma versão FOSS</string>
 
     <!-- System messages -->
     <string name="message_room_name_changed">Nome da sala alterado para: %1$s por %2$s</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -70,6 +70,9 @@
     <string name="msg_app_version">Версия программы: %1$s (%2$d)</string>
     <string name="msg_server_version">Версия сервера: %1$s</string>
     <string name="msg_send_analytics">Отправка аналитики</string>
+    <string name="msg_send_analytics_tracking">Отправлять анонимную статистику для улучшения приложения.</string>
+    <string name="msg_do_not_send_analytics_tracking">Не отправлять анонимную статистику для улучшения приложения</string>
+    <string name="msg_not_applicable_since_it_is_a_foss_version">Не применимо, так как это FOSS версия</string>
     <string name="msg_logout_from_rocket_chat">Выйти из Rocket.Chat</string>
     <string name="msg_delete_account">Удалить аккаунт</string>
     <string name="msg_change_status">Изменить статус</string>
@@ -216,12 +219,6 @@
     <string name="msg_member_already_added">Вы уже выбрали этого пользователя</string>
     <string name="msg_member_not_found">Пользователь не найден</string>
     <string name="msg_channel_created_successfully">Канал создан успешно</string>
-
-    <!-- Preferences messages -->
-    <string name="msg_analytics_tracking">Отслеживание аналитики</string>
-    <string name="msg_send_analytics_tracking">Отправлять анонимную статистику для улучшения приложения.</string>
-    <string name="msg_do_not_send_analytics_tracking">Не отправлять анонимную статистику для улучшения приложения</string>
-    <string name="msg_not_applicable_since_it_is_a_foss_version">Не применимо, так как это FOSS версия</string>
 
     <!-- System messages -->
     <string name="message_room_name_changed">%2$s изменил название канала на %1$s</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -70,6 +70,9 @@
     <string name="msg_app_version">Version: %1$s (%2$d)</string> <!-- TODO Translate -->
     <string name="msg_server_version">Server version: %1$s</string> <!-- TODO Translate -->
     <string name="msg_send_analytics">Send analytics</string> <!-- TODO Translate -->
+    <string name="msg_send_analytics_tracking">Uygulamanın gelişmesine katkıda bulunmak için anonim istatistik bilgisi gönder</string>
+    <string name="msg_do_not_send_analytics_tracking">Uygulamanın gelişmesine katkıda bulunmak için anonim istatistik bilgisi gönderme</string>
+    <string name="msg_not_applicable_since_it_is_a_foss_version">FOSS sürümü olduğundan uygulanabilir değil</string>
     <string name="msg_logout_from_rocket_chat">Logout from Rocket.Chat</string> <!-- TODO Translate -->
     <string name="msg_delete_account">Delete account</string> <!-- TODO Translate -->
     <string name="msg_change_status">Change status</string> <!-- TODO Translate -->
@@ -219,12 +222,6 @@
     <string name="msg_server">Server</string> <!-- TODO Translate -->
     <string name="msg_add_new_server">Add New Server</string>  <!-- TODO Translate -->
     <string name="msg_directory">Directory</string> <!-- TODO Translate -->
-
-    <!-- Preferences messages -->
-    <string name="msg_analytics_tracking">İstatistik takibi</string>
-    <string name="msg_send_analytics_tracking">Uygulamanın gelişmesine katkıda bulunmak için anonim istatistik bilgisi gönder</string>
-    <string name="msg_do_not_send_analytics_tracking">Uygulamanın gelişmesine katkıda bulunmak için anonim istatistik bilgisi gönderme</string>
-    <string name="msg_not_applicable_since_it_is_a_foss_version">FOSS sürümü olduğundan uygulanabilir değil</string>
 
     <!-- System messages -->
     <string name="message_room_name_changed">Oda ismi %2$s\'dan %1$s\'a değiştirildi</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -70,6 +70,9 @@
     <string name="msg_app_version">Version: %1$s (%2$d)</string> <!-- TODO Translate -->
     <string name="msg_server_version">Server version: %1$s</string> <!-- TODO Translate -->
     <string name="msg_send_analytics">Send analytics</string> <!-- TODO Translate -->
+    <string name="msg_send_analytics_tracking">Надсилати анонімну статистику для покращення роботи програми</string>
+    <string name="msg_do_not_send_analytics_tracking">Не надсилати анонімну статистику для покращення роботи програми</string>
+    <string name="msg_not_applicable_since_it_is_a_foss_version">Недоступно у FOSS версії</string>
     <string name="msg_logout_from_rocket_chat">Logout from Rocket.Chat</string> <!-- TODO Translate -->
     <string name="msg_delete_account">Delete account</string> <!-- TODO Translate -->
     <string name="msg_change_status">Change status</string> <!-- TODO Translate -->
@@ -215,12 +218,6 @@
     <string name="msg_member_already_added">Ви вже обрали цього користувача</string>
     <string name="msg_member_not_found">"Користувача не знайдено "</string>
     <string name="msg_channel_created_successfully">Канал був створений успішно</string>
-
-    <!-- Preferences messages -->
-    <string name="msg_analytics_tracking">Збір аналітики</string>
-    <string name="msg_send_analytics_tracking">Надсилати анонімну статистику для покращення роботи програми</string>
-    <string name="msg_do_not_send_analytics_tracking">Не надсилати анонімну статистику для покращення роботи програми</string>
-    <string name="msg_not_applicable_since_it_is_a_foss_version">Недоступно у FOSS версії</string>
 
     <!-- System messages -->
     <string name="message_room_name_changed">%2$s змінив назву каналу на %1$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -70,6 +70,9 @@
     <string name="msg_app_version">Version: %1$s (%2$d)</string> <!-- TODO Translate -->
     <string name="msg_server_version">Server version: %1$s</string> <!-- TODO Translate -->
     <string name="msg_send_analytics">Send analytics</string> <!-- TODO Translate -->
+    <string name="msg_send_analytics_tracking">发送匿名统计信息来帮助改善App</string>
+    <string name="msg_do_not_send_analytics_tracking">不要发送匿名统计信息，我不想帮组改善App</string>
+    <string name="msg_not_applicable_since_it_is_a_foss_version">不适用，因为这事开源软件</string>
     <string name="msg_logout_from_rocket_chat">Logout from Rocket.Chat</string> <!-- TODO Translate -->
     <string name="msg_delete_account">Delete account</string> <!-- TODO Translate -->
     <string name="msg_change_status">Change status</string> <!-- TODO Translate -->
@@ -216,12 +219,6 @@
     <string name="msg_view_more">显示更多</string>
     <string name="msg_view_less">显示更少</string>
     <string name="msg_muted_on_this_channel">您被禁言了</string>
-
-    <!-- Preferences messages -->
-    <string name="msg_analytics_tracking">跟踪分析</string>
-    <string name="msg_send_analytics_tracking">发送匿名统计信息来帮助改善App</string>
-    <string name="msg_do_not_send_analytics_tracking">不要发送匿名统计信息，我不想帮组改善App</string>
-    <string name="msg_not_applicable_since_it_is_a_foss_version">不适用，因为这事开源软件</string>
 
     <!-- System messages -->
     <string name="message_room_name_changed">频道名改为: %1$s by %2$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -70,6 +70,9 @@
     <string name="msg_app_version">Version: %1$s (%2$d)</string> <!-- TODO Translate -->
     <string name="msg_server_version">Server version: %1$s</string> <!-- TODO Translate -->
     <string name="msg_send_analytics">Send analytics</string> <!-- TODO Translate -->
+    <string name="msg_send_analytics_tracking">發送匿名訊息來改善App</string>
+    <string name="msg_do_not_send_analytics_tracking">不要發送匿名訊息，我不想幫助這個App</string>
+    <string name="msg_not_applicable_since_it_is_a_foss_version">不適用，因為這個軟體是Foss版本</string>
     <string name="msg_logout_from_rocket_chat">Logout from Rocket.Chat</string> <!-- TODO Translate -->
     <string name="msg_delete_account">Delete account</string> <!-- TODO Translate -->
     <string name="msg_change_status">Change status</string> <!-- TODO Translate -->
@@ -197,12 +200,6 @@
     <string name="msg_view_more">顯示更多</string>
     <string name="msg_view_less">顯示更少</string>
     <string name="msg_muted_on_this_channel">您被禁言了</string>
-
-    <!-- Preferences messages -->
-    <string name="msg_analytics_tracking">追蹤分析</string>
-    <string name="msg_send_analytics_tracking">發送匿名訊息來改善App</string>
-    <string name="msg_do_not_send_analytics_tracking">不要發送匿名訊息，我不想幫助這個App</string>
-    <string name="msg_not_applicable_since_it_is_a_foss_version">不適用，因為這個軟體是Foss版本</string>
 
     <!-- System messages -->
     <string name="message_room_name_changed">頻道已經改名為: %1$s by %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,9 @@ https://github.com/RocketChat/java-code-styles/blob/master/CODING_STYLE.md#strin
     <string name="msg_app_version">Version: %1$s (%2$d)</string>
     <string name="msg_server_version">Server version: %1$s</string>
     <string name="msg_send_analytics">Send analytics</string>
+    <string name="msg_send_analytics_tracking">Send anonymous statistics to help improve this app</string>
+    <string name="msg_do_not_send_analytics_tracking">Do not send anonymous statistics to help improve this app</string>
+    <string name="msg_not_applicable_since_it_is_a_foss_version">Not applicable since it is a FOSS version</string>
     <string name="msg_logout_from_rocket_chat">Logout from Rocket.Chat</string>
     <string name="msg_delete_account">Delete account</string>
     <string name="msg_change_status">Change status</string>
@@ -232,12 +235,6 @@ https://github.com/RocketChat/java-code-styles/blob/master/CODING_STYLE.md#strin
     <string name="msg_view_more">view more</string>
     <string name="msg_view_less">view less</string>
     <string name="msg_muted_on_this_channel">You are muted on this channel</string>
-
-    <!-- Preferences messages -->
-    <string name="msg_analytics_tracking">Analytics tracking</string>
-    <string name="msg_send_analytics_tracking">Send anonymous statistics to help improve this app</string>
-    <string name="msg_do_not_send_analytics_tracking">Do not send anonymous statistics to help improve this app</string>
-    <string name="msg_not_applicable_since_it_is_a_foss_version">Not applicable since it is a FOSS version</string>
 
     <!-- System messages -->
     <string name="message_room_name_changed">Room name changed to: %1$s by %2$s</string>

--- a/draw/src/main/res/drawable/ic_send_black_24dp.xml
+++ b/draw/src/main/res/drawable/ic_send_black_24dp.xml
@@ -1,9 +1,10 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
     <path
         android:fillColor="#FF000000"
-        android:pathData="M2.01,21L23,12 2.01,3 2,10l15,2 -15,2z"/>
+        android:pathData="M2.01,21L23,12 2.01,3 2,10l15,2 -15,2z" />
 </vector>

--- a/emoji/src/main/java/chat/rocket/android/emoji/EmojiKeyboardPopup.kt
+++ b/emoji/src/main/java/chat/rocket/android/emoji/EmojiKeyboardPopup.kt
@@ -16,7 +16,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.graphics.drawable.DrawableCompat
-import androidx.viewpager.widget.ViewPager
 import chat.rocket.android.emoji.internal.EmojiCategory
 import chat.rocket.android.emoji.internal.EmojiPagerAdapter
 import chat.rocket.android.emoji.internal.PREF_EMOJI_SKIN_TONE
@@ -27,7 +26,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
 class EmojiKeyboardPopup(context: Context, view: View) : OverKeyboardPopupWindow(context, view) {
-    private lateinit var viewPager: ViewPager
+    private lateinit var viewPager: EmojiViewPager
     private lateinit var tabLayout: TabLayout
     private lateinit var searchView: View
     private lateinit var backspaceView: View
@@ -155,7 +154,7 @@ class EmojiKeyboardPopup(context: Context, view: View) : OverKeyboardPopupWindow
                     val fragments = (it as AppCompatActivity).supportFragmentManager.fragments
                     if (fragments.size == 0 || fragments[0] !is EmojiKeyboardListener) {
                         // Since the app can arrive in an inconsistent state at this point, do not throw
-//                        throw IllegalStateException("activity/fragment should implement Listener interface")
+                        // throw IllegalStateException("activity/fragment should implement Listener interface")
                         null
                     } else {
                         fragments[0] as EmojiKeyboardListener
@@ -177,8 +176,8 @@ class EmojiKeyboardPopup(context: Context, view: View) : OverKeyboardPopupWindow
                 val tab = tabLayout.getTabAt(category.ordinal)
                 val tabView = LayoutInflater.from(context).inflate(R.layout.emoji_picker_tab, null)
                 tab?.customView = tabView
-                val textView = tabView.findViewById(R.id.image_category) as ImageView
-                textView.setImageResource(category.resourceIcon())
+                val imageView = tabView.findViewById(R.id.image_category) as ImageView
+                imageView.setImageResource(category.resourceIcon())
             }
 
             val currentTab = if (EmojiRepository.getRecents().isEmpty()) {
@@ -186,7 +185,6 @@ class EmojiKeyboardPopup(context: Context, view: View) : OverKeyboardPopupWindow
             } else {
                 EmojiCategory.RECENTS.ordinal
             }
-
             viewPager.currentItem = currentTab
         }
     }
@@ -203,7 +201,7 @@ class EmojiKeyboardPopup(context: Context, view: View) : OverKeyboardPopupWindow
                 val start = message.getSpanStart(span)
                 val end = message.getSpanEnd(span)
 
-                // Remove the span
+                // Remove the span.
                 message.removeSpan(span)
 
                 // Remove the remaining emoticon text.

--- a/emoji/src/main/java/chat/rocket/android/emoji/EmojiPickerPopup.kt
+++ b/emoji/src/main/java/chat/rocket/android/emoji/EmojiPickerPopup.kt
@@ -7,9 +7,6 @@ import android.view.LayoutInflater
 import android.view.Window
 import android.view.WindowManager
 import android.widget.ImageView
-import androidx.annotation.ColorInt
-import androidx.core.content.ContextCompat
-import androidx.core.content.edit
 import chat.rocket.android.emoji.internal.EmojiCategory
 import chat.rocket.android.emoji.internal.EmojiPagerAdapter
 import chat.rocket.android.emoji.internal.PREF_EMOJI_SKIN_TONE
@@ -17,7 +14,6 @@ import kotlinx.android.synthetic.main.emoji_picker.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-
 
 class EmojiPickerPopup(context: Context) : Dialog(context) {
 
@@ -60,15 +56,15 @@ class EmojiPickerPopup(context: Context) : Dialog(context) {
             changeSkinTone(Fitzpatrick.valueOf(it))
         }
 
-        pager_categories.adapter = adapter
         pager_categories.offscreenPageLimit = EmojiCategory.values().size
+        pager_categories.adapter = adapter
 
         for (category in EmojiCategory.values()) {
             val tab = tabs.getTabAt(category.ordinal)
             val tabView = LayoutInflater.from(context).inflate(R.layout.emoji_picker_tab, null)
             tab?.customView = tabView
-            val textView = tabView.findViewById(R.id.image_category) as ImageView
-            textView.setImageResource(category.resourceIcon())
+            val imageView = tabView.findViewById(R.id.image_category) as ImageView
+            imageView.setImageResource(category.resourceIcon())
         }
 
         val currentTab = if (EmojiRepository.getRecents().isEmpty()) {

--- a/emoji/src/main/java/chat/rocket/android/emoji/EmojiViewPager.kt
+++ b/emoji/src/main/java/chat/rocket/android/emoji/EmojiViewPager.kt
@@ -1,0 +1,289 @@
+package chat.rocket.android.emoji
+
+import android.content.Context
+import android.database.DataSetObserver
+import android.os.Parcelable
+import android.util.AttributeSet
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.viewpager.widget.PagerAdapter
+import androidx.viewpager.widget.ViewPager
+
+class EmojiViewPager : ViewPager {
+
+    private var mLayoutDirection = ViewCompat.LAYOUT_DIRECTION_LTR
+    private val mPageChangeListeners = hashMapOf<OnPageChangeListener, ReversingOnPageChangeListener>()
+
+    private val isRtl: Boolean
+        get() = mLayoutDirection == ViewCompat.LAYOUT_DIRECTION_RTL
+
+    constructor(context: Context) : super(context)
+
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
+
+    override fun onRtlPropertiesChanged(layoutDirection: Int) {
+        super.onRtlPropertiesChanged(layoutDirection)
+        val viewCompatLayoutDirection = if (layoutDirection == View.LAYOUT_DIRECTION_RTL) {
+            ViewCompat.LAYOUT_DIRECTION_RTL
+        } else {
+            ViewCompat.LAYOUT_DIRECTION_LTR
+        }
+        if (viewCompatLayoutDirection != mLayoutDirection) {
+            val adapter = super.getAdapter()
+            var position = 0
+            if (adapter != null) {
+                position = currentItem
+            }
+            mLayoutDirection = viewCompatLayoutDirection
+            if (adapter != null) {
+                adapter.notifyDataSetChanged()
+                currentItem = position
+            }
+        }
+    }
+
+    override fun setAdapter(adapter: PagerAdapter?) {
+        val adapter = if (adapter != null) {
+            ReversingAdapter(adapter)
+        } else {
+            adapter
+        }
+        super.setAdapter(adapter)
+        currentItem = 0
+    }
+
+    override fun getAdapter(): PagerAdapter? {
+        return super.getAdapter() as ReversingAdapter?
+    }
+
+    override fun getCurrentItem(): Int {
+        var item = super.getCurrentItem()
+        val adapter = super.getAdapter()
+        if (adapter != null && isRtl) {
+            item = adapter.count - item - 1
+        }
+        return item
+    }
+
+    override fun setCurrentItem(position: Int, smoothScroll: Boolean) {
+        val adapter = super.getAdapter()
+        val position = if (adapter != null && isRtl) {
+            adapter.count - position - 1
+        } else {
+            position
+        }
+        super.setCurrentItem(position, smoothScroll)
+    }
+
+    override fun setCurrentItem(position: Int) {
+        val adapter = super.getAdapter()
+        val position = if (adapter != null && isRtl) {
+            adapter.count - position - 1
+        } else {
+            position
+        }
+        super.setCurrentItem(position)
+    }
+
+    override fun setOnPageChangeListener(listener: OnPageChangeListener) {
+        super.setOnPageChangeListener(ReversingOnPageChangeListener(listener))
+    }
+
+    override fun addOnPageChangeListener(listener: OnPageChangeListener) {
+        val reversingListener = ReversingOnPageChangeListener(listener)
+        mPageChangeListeners.put(listener, reversingListener)
+        super.addOnPageChangeListener(reversingListener)
+    }
+
+    override fun removeOnPageChangeListener(listener: OnPageChangeListener) {
+        val reverseListener = mPageChangeListeners.remove(listener)
+        if (reverseListener != null) {
+            super.removeOnPageChangeListener(reverseListener)
+        }
+    }
+
+    override fun clearOnPageChangeListeners() {
+        super.clearOnPageChangeListeners()
+        mPageChangeListeners.clear()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val heightMeasureSpec = if (MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.UNSPECIFIED) {
+            var height = 0
+            for (i in 0 until childCount) {
+                val child = getChildAt(i)
+                child.measure(widthMeasureSpec, MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED))
+                val h = child.measuredHeight
+                if (h > height) {
+                    height = h
+                }
+            }
+            MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+        } else {
+            heightMeasureSpec
+        }
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+    }
+
+    private inner class ReversingOnPageChangeListener(
+        private val mListener: OnPageChangeListener
+    ) : OnPageChangeListener {
+
+        override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
+            var position = position
+            var positionOffset = positionOffset
+            var positionOffsetPixels = positionOffsetPixels
+            val width = width
+            val adapter = super@EmojiViewPager.getAdapter()
+            if (adapter != null && isRtl) {
+                val count = adapter.count
+                var remainingWidth = (width * (1 - adapter.getPageWidth(position))).toInt() +
+                    positionOffsetPixels
+                while (position < count && remainingWidth > 0) {
+                    position += 1
+                    remainingWidth -= (width * adapter.getPageWidth(position)).toInt()
+                }
+                position = count - position - 1
+                positionOffsetPixels = -remainingWidth
+                positionOffset = positionOffsetPixels / (width * adapter.getPageWidth(position))
+            }
+            mListener.onPageScrolled(position, positionOffset, positionOffsetPixels)
+        }
+
+        override fun onPageSelected(position: Int) {
+            val adapter = super@EmojiViewPager.getAdapter()
+            val position = if (adapter != null && isRtl) {
+                adapter.count - position - 1
+            } else {
+                position
+            }
+            mListener.onPageSelected(position)
+        }
+
+        override fun onPageScrollStateChanged(state: Int) {
+            mListener.onPageScrollStateChanged(state)
+        }
+    }
+
+    private inner class ReversingAdapter(private val adapter: PagerAdapter) : PagerAdapter() {
+
+        override fun isViewFromObject(view: View, obj: Any): Boolean {
+            return adapter.isViewFromObject(view, obj)
+        }
+
+        override fun getCount(): Int {
+            return adapter.count
+        }
+
+        override fun getItemPosition(obj: Any): Int {
+            var position = adapter.getItemPosition(obj)
+            if (isRtl) {
+                if (position == POSITION_UNCHANGED || position == POSITION_NONE) {
+                    position = POSITION_NONE
+                } else {
+                    position = getCount() - position - 1
+                }
+            }
+            return position
+        }
+
+        override fun getPageTitle(position: Int): CharSequence? {
+            return adapter.getPageTitle(position)
+        }
+
+        override fun getPageWidth(position: Int): Float {
+            return adapter.getPageWidth(position)
+        }
+
+        override fun instantiateItem(container: ViewGroup, position: Int): Any {
+            val position = if (isRtl) {
+                count - position - 1
+            } else {
+                position
+            }
+            return adapter.instantiateItem(container, position)
+        }
+
+        override fun instantiateItem(container: View, position: Int): Any {
+            val position = if (isRtl) {
+                count - position - 1
+            } else {
+                position
+            }
+            return adapter.instantiateItem(container, position)
+        }
+
+        override fun destroyItem(container: ViewGroup, position: Int, obj: Any) {
+            val position = if (isRtl) {
+                count - position - 1
+            } else {
+                position
+            }
+            adapter.destroyItem(container, position, obj)
+        }
+
+        override fun destroyItem(container: View, position: Int, obj: Any) {
+            val position = if (isRtl) {
+                count - position - 1
+            } else {
+                position
+            }
+            adapter.destroyItem(container, position, obj)
+        }
+
+        override fun setPrimaryItem(container: ViewGroup, position: Int, obj: Any) {
+            val position = if (isRtl) {
+                count - position - 1
+            } else {
+                position
+            }
+            adapter.setPrimaryItem(container, position, obj)
+        }
+
+        override fun setPrimaryItem(container: View, position: Int, obj: Any) {
+            val position = if (isRtl) {
+                count - position - 1
+            } else {
+                position
+            }
+            adapter.setPrimaryItem(container, position, obj)
+        }
+
+        override fun startUpdate(container: ViewGroup) {
+            adapter.startUpdate(container)
+        }
+
+        override fun startUpdate(container: View) {
+            adapter.startUpdate(container)
+        }
+
+        override fun finishUpdate(container: ViewGroup) {
+            adapter.finishUpdate(container)
+        }
+
+        override fun finishUpdate(container: View) {
+            adapter.finishUpdate(container)
+        }
+
+        override fun saveState(): Parcelable? {
+            return adapter.saveState()
+        }
+
+        override fun restoreState(state: Parcelable?, loader: ClassLoader?) {
+            adapter.restoreState(state, loader)
+        }
+
+        override fun notifyDataSetChanged() {
+            adapter.notifyDataSetChanged()
+        }
+
+        override fun registerDataSetObserver(observer: DataSetObserver) {
+            adapter.registerDataSetObserver(observer)
+        }
+
+        override fun unregisterDataSetObserver(observer: DataSetObserver) {
+            adapter.unregisterDataSetObserver(observer)
+        }
+    }
+}

--- a/emoji/src/main/res/drawable/ic_backspace_gray_24dp.xml
+++ b/emoji/src/main/res/drawable/ic_backspace_gray_24dp.xml
@@ -2,6 +2,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
+    android:autoMirrored="true"
     android:viewportHeight="24"
     android:viewportWidth="24">
 

--- a/emoji/src/main/res/layout-land/emoji_picker.xml
+++ b/emoji/src/main/res/layout-land/emoji_picker.xml
@@ -15,7 +15,7 @@
         app:tabGravity="fill"
         app:tabMode="scrollable" />
 
-    <androidx.viewpager.widget.ViewPager
+    <chat.rocket.android.emoji.EmojiViewPager
         android:id="@+id/pager_categories"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/emoji/src/main/res/layout/emoji_picker.xml
+++ b/emoji/src/main/res/layout/emoji_picker.xml
@@ -16,7 +16,7 @@
         app:tabMaxWidth="48dp"
         app:tabMode="scrollable" />
 
-    <androidx.viewpager.widget.ViewPager
+    <chat.rocket.android.emoji.EmojiViewPager
         android:id="@+id/pager_categories"
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
@RocketChat/android

Closes #2301

Hopefully this pull request is the last one to fully support RTL languages in Rocket.Chat Android app.

The RTL ViewPager is based on [Duolingo's RtlViewPager](https://github.com/duolingo/rtl-viewpager); however, I rewrote the code in Kotlin, and modified some parts of it.

#### Changes:

1. Added support for RTL ViewPager. Now one can swipe from right to left in Emoji Picker fragments for RTL languages.
2. Made message send icon (`ic_send_24dp.xml`), drawing send icon (`ic_send_black_24dp.xml`) and backspace icon (`ic_backspace_gray_24dp.xml`) be auto-mirrored for RTL languages.
3. Merged _Preferences messages_ with _Settings messages_ in all strings resource files.
4. Corrected some typos and translation mistakes in Arabic strings resource file.

**Note:** There is a known bug, however, as displayed in the GIF, in which sometimes the tabs of Emoji categories are in text instead of icons. I doubt though that this issue has something to deal with the adapter. The adapter is working perfectly. I tried debugging a lot, and tried checking for line 180 in `EmojiKeyboardPopup` and line 67 in `EmojiPickerPopup`, and the resource icon is always set, but does not appear on the layout. I think the issue might be in _lines 177, 178_ in `EmojiKeyboardPopup` and _lines 64, 65_ in `EmojiPickerPopup`; however, that's just a guess. I do not know the issue exactly. I also noticed it depends on the width of the tabs. If you tried rotating your device to landscape mode, things can change here.

#### GIF for the change:

![RTL ViewPager](https://user-images.githubusercontent.com/20887574/57303159-04ac6100-70dd-11e9-9790-a240167e7baf.gif)