### PR TITLE
[FIX] Fixes bottom sheets not being scrollable and completely visible

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
@@ -548,7 +548,7 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardListener, EmojiR
                 if (newMessageCount <= 99) {
                     text_count.text = newMessageCount.toString()
                 } else {
-                    text_count.text = "99+"
+                    text_count.text = getString(R.string.msg_more_than_ninety_nine_unread_messages)
                 }
                 text_count.isVisible = true
             } else if (!button_fab.isVisible) {

--- a/app/src/main/java/chat/rocket/android/directory/ui/DirectorySortingBottomSheetFragment.kt
+++ b/app/src/main/java/chat/rocket/android/directory/ui/DirectorySortingBottomSheetFragment.kt
@@ -1,7 +1,6 @@
 package chat.rocket.android.directory.ui
 
 import DrawableHelper
-import android.content.DialogInterface
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -10,6 +9,8 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.FragmentManager
 import chat.rocket.android.R
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import kotlinx.android.synthetic.main.bottom_sheet_fragment_directory_sorting.*
 
@@ -67,10 +68,6 @@ class DirectorySortingBottomSheetFragment : BottomSheetDialogFragment() {
         setupListeners()
     }
 
-    override fun onCancel(dialog: DialogInterface?) {
-        super.onCancel(dialog)
-    }
-
     private fun setupView() {
         if (isSortByChannels) {
             checkSelection(text_channels, hashtagDrawable)
@@ -82,6 +79,15 @@ class DirectorySortingBottomSheetFragment : BottomSheetDialogFragment() {
     }
 
     private fun setupListeners() {
+        dialog.setOnShowListener { dialog ->
+            val bottomSheet = (dialog as BottomSheetDialog).findViewById<View>(
+                com.google.android.material.R.id.design_bottom_sheet
+            )
+            bottomSheet?.let {
+                BottomSheetBehavior.from(bottomSheet).peekHeight = bottomSheet.height
+            }
+        }
+
         text_channels.setOnClickListener {
             checkSelection(text_channels, hashtagDrawable)
             uncheckSelection(text_users, userDrawable)

--- a/app/src/main/java/chat/rocket/android/servers/ui/ServersBottomSheetFragment.kt
+++ b/app/src/main/java/chat/rocket/android/servers/ui/ServersBottomSheetFragment.kt
@@ -12,6 +12,8 @@ import chat.rocket.android.servers.adapter.ServersAdapter
 import chat.rocket.android.servers.presentation.ServersPresenter
 import chat.rocket.android.servers.presentation.ServersView
 import chat.rocket.android.util.extensions.showToast
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.bottom_sheet_fragment_servers.*
@@ -38,6 +40,18 @@ class ServersBottomSheetFragment : BottomSheetDialogFragment(), ServersView {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         presenter.getAllServers()
+        setupListeners()
+    }
+
+    private fun setupListeners() {
+        dialog.setOnShowListener { dialog ->
+            val bottomSheet = (dialog as BottomSheetDialog).findViewById<View>(
+                com.google.android.material.R.id.design_bottom_sheet
+            )
+            bottomSheet?.let {
+                BottomSheetBehavior.from(bottomSheet).peekHeight = bottomSheet.height
+            }
+        }
     }
 
     override fun showServerList(serverList: List<Account>, currentServerUrl: String) {

--- a/app/src/main/java/chat/rocket/android/sortingandgrouping/ui/SortingAndGroupingBottomSheetFragment.kt
+++ b/app/src/main/java/chat/rocket/android/sortingandgrouping/ui/SortingAndGroupingBottomSheetFragment.kt
@@ -13,6 +13,8 @@ import chat.rocket.android.chatrooms.ui.ChatRoomsFragment
 import chat.rocket.android.chatrooms.ui.TAG_CHAT_ROOMS_FRAGMENT
 import chat.rocket.android.sortingandgrouping.presentation.SortingAndGroupingPresenter
 import chat.rocket.android.sortingandgrouping.presentation.SortingAndGroupingView
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.bottom_sheet_fragment_sort_by.*
@@ -89,6 +91,15 @@ class SortingAndGroupingBottomSheetFragment : BottomSheetDialogFragment(), Sorti
     }
 
     private fun setupListeners() {
+        dialog.setOnShowListener { dialog ->
+            val bottomSheet = (dialog as BottomSheetDialog).findViewById<View>(
+                com.google.android.material.R.id.design_bottom_sheet
+            )
+            bottomSheet?.let {
+                BottomSheetBehavior.from(bottomSheet).peekHeight = bottomSheet.height
+            }
+        }
+
         text_name.setOnClickListener {
             changeSortByTitle(getString(R.string.msg_sort_by_name))
             checkSelection(text_name, filterDrawable)

--- a/app/src/main/res/layout/bottom_sheet_fragment_directory_sorting.xml
+++ b/app/src/main/res/layout/bottom_sheet_fragment_directory_sorting.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
     tools:context=".directory.ui.DirectorySortingBottomSheetFragment">
 
     <TextView
@@ -16,96 +17,106 @@
         android:text="@string/msg_sort_by"
         android:textColor="#9EA2A8"
         android:textSize="17sp"
-        android:textStyle="normal"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:textStyle="normal" />
 
     <View
         android:id="@+id/view_divider_one"
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_marginTop="16dp"
-        android:background="#1F000000"
-        app:layout_constraintTop_toBottomOf="@+id/text_sort_by" />
+        android:background="#1F000000" />
 
-    <TextView
-        android:id="@+id/text_channels"
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:drawableStart="@drawable/ic_hashtag_16dp"
-        android:drawablePadding="16dp"
-        android:paddingStart="16dp"
-        android:paddingTop="16dp"
-        android:paddingEnd="16dp"
-        android:paddingBottom="16dp"
-        android:text="@string/msg_channels"
-        android:textColor="#2F343D"
-        android:textSize="16sp"
-        android:textStyle="normal"
-        app:layout_constraintTop_toBottomOf="@+id/view_divider_one" />
+        android:layout_height="wrap_content">
 
-    <TextView
-        android:id="@+id/text_users"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:drawableStart="@drawable/ic_user_16dp"
-        android:drawablePadding="16dp"
-        android:paddingStart="16dp"
-        android:paddingTop="16dp"
-        android:paddingEnd="16dp"
-        android:paddingBottom="16dp"
-        android:text="@string/msg_users"
-        android:textColor="#2F343D"
-        android:textSize="16sp"
-        android:textStyle="normal"
-        app:layout_constraintTop_toBottomOf="@+id/text_channels" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
-    <View
-        android:id="@+id/view_divider_two"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:background="#1F000000"
-        app:layout_constraintTop_toBottomOf="@+id/text_users" />
+            <TextView
+                android:id="@+id/text_channels"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:drawableStart="@drawable/ic_hashtag_16dp"
+                android:drawablePadding="16dp"
+                android:paddingStart="16dp"
+                android:paddingTop="16dp"
+                android:paddingEnd="16dp"
+                android:paddingBottom="16dp"
+                android:text="@string/msg_channels"
+                android:textColor="#2F343D"
+                android:textSize="16sp"
+                android:textStyle="normal"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:id="@+id/text_search_for_global_users"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingStart="16dp"
-        android:paddingTop="16dp"
-        android:paddingEnd="16dp"
-        android:text="@string/msg_search_for_global_users"
-        android:textColor="#2F343D"
-        android:textSize="16sp"
-        android:textStyle="normal"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/view_divider_two" />
+            <TextView
+                android:id="@+id/text_users"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:drawableStart="@drawable/ic_user_16dp"
+                android:drawablePadding="16dp"
+                android:paddingStart="16dp"
+                android:paddingTop="16dp"
+                android:paddingEnd="16dp"
+                android:paddingBottom="16dp"
+                android:text="@string/msg_users"
+                android:textColor="#2F343D"
+                android:textSize="16sp"
+                android:textStyle="normal"
+                app:layout_constraintTop_toBottomOf="@+id/text_channels" />
 
-    <Switch
-        android:id="@+id/switch_global_users"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:checked="false"
-        app:layout_constraintBottom_toBottomOf="@+id/text_search_for_global_users"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/text_search_for_global_users" />
+            <View
+                android:id="@+id/view_divider_two"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:background="#1F000000"
+                app:layout_constraintTop_toBottomOf="@+id/text_users" />
 
-    <TextView
-        android:id="@+id/text_search_for_global_users_description"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        android:paddingBottom="16dp"
-        android:text="@string/msg_search_for_global_users_description"
-        android:textColor="#9EA2A8"
-        android:textSize="14sp"
-        android:textStyle="normal"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/text_search_for_global_users" />
+            <TextView
+                android:id="@+id/text_search_for_global_users"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="16dp"
+                android:paddingTop="16dp"
+                android:paddingEnd="16dp"
+                android:text="@string/msg_search_for_global_users"
+                android:textColor="#2F343D"
+                android:textSize="16sp"
+                android:textStyle="normal"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/view_divider_two" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+            <Switch
+                android:id="@+id/switch_global_users"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:checked="false"
+                app:layout_constraintBottom_toBottomOf="@+id/text_search_for_global_users"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/text_search_for_global_users" />
+
+            <TextView
+                android:id="@+id/text_search_for_global_users_description"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingBottom="16dp"
+                android:text="@string/msg_search_for_global_users_description"
+                android:textColor="#9EA2A8"
+                android:textSize="14sp"
+                android:textStyle="normal"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/text_search_for_global_users" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/bottom_sheet_fragment_sort_by.xml
+++ b/app/src/main/res/layout/bottom_sheet_fragment_sort_by.xml
@@ -24,86 +24,100 @@
         android:layout_marginTop="16dp"
         android:background="#1F000000" />
 
-    <TextView
-        android:id="@+id/text_name"
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:drawableStart="@drawable/ic_filter_20dp"
-        android:drawablePadding="16dp"
-        android:paddingStart="16dp"
-        android:paddingTop="16dp"
-        android:paddingEnd="16dp"
-        android:paddingBottom="16dp"
-        android:text="@string/msg_sort_by_name"
-        android:textColor="#2F343D"
-        android:textSize="16sp"
-        android:textStyle="normal" />
+        android:layout_height="wrap_content">
 
-    <TextView
-        android:id="@+id/text_activity"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:drawableStart="@drawable/ic_activity_20dp"
-        android:drawablePadding="16dp"
-        android:paddingStart="16dp"
-        android:paddingTop="16dp"
-        android:paddingEnd="16dp"
-        android:paddingBottom="16dp"
-        android:text="@string/msg_sort_by_activity"
-        android:textColor="#2F343D"
-        android:textSize="16sp"
-        android:textStyle="normal" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
-    <View
-        android:id="@+id/view_divider"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:background="#1F000000" />
+            <TextView
+                android:id="@+id/text_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:drawableStart="@drawable/ic_filter_20dp"
+                android:drawablePadding="16dp"
+                android:paddingStart="16dp"
+                android:paddingTop="16dp"
+                android:paddingEnd="16dp"
+                android:paddingBottom="16dp"
+                android:text="@string/msg_sort_by_name"
+                android:textColor="#2F343D"
+                android:textSize="16sp"
+                android:textStyle="normal" />
 
-    <TextView
-        android:id="@+id/text_unread_on_top"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:drawableStart="@drawable/ic_unread_20dp"
-        android:drawablePadding="16dp"
-        android:paddingStart="16dp"
-        android:paddingTop="16dp"
-        android:paddingEnd="16dp"
-        android:paddingBottom="16dp"
-        android:text="@string/msg_group_by_unread_on_top"
-        android:textColor="#2F343D"
-        android:textSize="16sp"
-        android:textStyle="normal" />
+            <TextView
+                android:id="@+id/text_activity"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:drawableStart="@drawable/ic_activity_20dp"
+                android:drawablePadding="16dp"
+                android:paddingStart="16dp"
+                android:paddingTop="16dp"
+                android:paddingEnd="16dp"
+                android:paddingBottom="16dp"
+                android:text="@string/msg_sort_by_activity"
+                android:textColor="#2F343D"
+                android:textSize="16sp"
+                android:textStyle="normal" />
 
-    <TextView
-        android:id="@+id/text_group_by_type"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:drawableStart="@drawable/ic_group_by_type_20dp"
-        android:drawablePadding="16dp"
-        android:paddingStart="16dp"
-        android:paddingTop="16dp"
-        android:paddingEnd="16dp"
-        android:paddingBottom="16dp"
-        android:text="@string/msg_group_by_type"
-        android:textColor="#2F343D"
-        android:textSize="16sp"
-        android:textStyle="normal" />
+            <View
+                android:id="@+id/view_divider"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:background="#1F000000" />
 
-    <TextView
-        android:id="@+id/text_group_by_favorites"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:drawableStart="@drawable/ic_favorites_20dp"
-        android:drawablePadding="16dp"
-        android:paddingStart="16dp"
-        android:paddingTop="16dp"
-        android:paddingEnd="16dp"
-        android:paddingBottom="16dp"
-        android:text="@string/msg_group_by_favorites"
-        android:textColor="#2F343D"
-        android:textSize="16sp"
-        android:textStyle="normal" />
+            <TextView
+                android:id="@+id/text_unread_on_top"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:drawableStart="@drawable/ic_unread_20dp"
+                android:drawablePadding="16dp"
+                android:paddingStart="16dp"
+                android:paddingTop="16dp"
+                android:paddingEnd="16dp"
+                android:paddingBottom="16dp"
+                android:text="@string/msg_group_by_unread_on_top"
+                android:textColor="#2F343D"
+                android:textSize="16sp"
+                android:textStyle="normal" />
+
+            <TextView
+                android:id="@+id/text_group_by_type"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:drawableStart="@drawable/ic_group_by_type_20dp"
+                android:drawablePadding="16dp"
+                android:paddingStart="16dp"
+                android:paddingTop="16dp"
+                android:paddingEnd="16dp"
+                android:paddingBottom="16dp"
+                android:text="@string/msg_group_by_type"
+                android:textColor="#2F343D"
+                android:textSize="16sp"
+                android:textStyle="normal" />
+
+            <TextView
+                android:id="@+id/text_group_by_favorites"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:drawableStart="@drawable/ic_favorites_20dp"
+                android:drawablePadding="16dp"
+                android:paddingStart="16dp"
+                android:paddingTop="16dp"
+                android:paddingEnd="16dp"
+                android:paddingBottom="16dp"
+                android:text="@string/msg_group_by_favorites"
+                android:textColor="#2F343D"
+                android:textSize="16sp"
+                android:textStyle="normal" />
+
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
 </LinearLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -103,10 +103,10 @@
     <string name="msg_share_using">نشر بواسطة</string>
     <string name="msg_profile_updated_successfully">تم تحديث الملف الشخصي بنجاح</string>
     <string name="msg_username">اسم المستخدم</string>
-    <string name="msg_username_or_email">اسم المستخدم أو عنوان بريد</string>
+    <string name="msg_username_or_email">اسم المستخدم أو عنوان البريد</string>
     <string name="msg_password">كلمة السر</string>
     <string name="msg_name">الاسم</string>
-    <string name="msg_email">عنوان بريد</string>
+    <string name="msg_email">عنوان البريد</string>
     <string name="msg_avatar_url">رابط الشخصية</string>
     <string name="msg_or_continue_using_social_accounts">استمرار باستخدام حساب التواصل الاجتماعي</string>
     <string name="msg_new_user">مستخدم جديد؟ %1$s</string>


### PR DESCRIPTION
@RocketChat/android

Closes #2253
Closes #2277

#### Changes:

1. Fixed bottom sheets not being scrollable when the sheet is too long for the device screen. Initially one could not scroll.
2. Fixed bottom sheets not being completely visible when the sheet is too long for the device screen.
3. Fixed hardcoded string _"+99"_ in `ChatRoomFragment`.
4. Corrected 2 translations in Arabic language.

#### GIFs for the change:

**Portrait:**
![Bottom Sheet Portrait](https://user-images.githubusercontent.com/20887574/57989984-4dcbc000-7aa2-11e9-8c6b-3408be04a0eb.gif)

**Landscape:**
![Bottom Sheet Landscape](https://user-images.githubusercontent.com/20887574/57989883-6daeb400-7aa1-11e9-84da-6616710dc3b1.gif)