### PR TITLE
[FIX] Fixes issues and memory leaks after changing language

### DIFF
--- a/app/src/main/java/chat/rocket/android/directory/presentation/DirectoryPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/directory/presentation/DirectoryPresenter.kt
@@ -136,7 +136,7 @@ class DirectoryPresenter @Inject constructor(
         }
     }
 
-    fun tiDirectMessage(username: String, name: String) {
+    fun toDirectMessage(username: String, name: String) {
         launchUI(strategy) {
             try {
                 view.showLoading()

--- a/app/src/main/java/chat/rocket/android/directory/ui/DirectoryFragment.kt
+++ b/app/src/main/java/chat/rocket/android/directory/ui/DirectoryFragment.kt
@@ -49,10 +49,10 @@ class DirectoryFragment : Fragment(), DirectoryView {
             presenter.toChannel(channelId, channelName)
         }
         override fun onUserSelected(username: String, name: String) {
-            presenter.tiDirectMessage(username, name)
+            presenter.toDirectMessage(username, name)
         }
         override fun onGlobalUserSelected(username: String, name: String) {
-            presenter.tiDirectMessage(username, name)
+            presenter.toDirectMessage(username, name)
         }
     })
     private val hashtagDrawable by lazy {

--- a/app/src/main/java/chat/rocket/android/main/presentation/MainNavigator.kt
+++ b/app/src/main/java/chat/rocket/android/main/presentation/MainNavigator.kt
@@ -1,5 +1,6 @@
 package chat.rocket.android.main.presentation
 
+import android.content.Intent
 import chat.rocket.android.R
 import chat.rocket.android.authentication.ui.newServerIntent
 import chat.rocket.android.chatroom.ui.chatRoomIntent
@@ -99,5 +100,10 @@ class MainNavigator(internal val activity: MainActivity) {
 
     fun toServerScreen() {
         activity.startActivity(activity.newServerIntent())
+    }
+
+    fun recreateActivity() {
+        activity.startActivity(Intent(activity, MainActivity::class.java))
+        activity.finish()
     }
 }

--- a/app/src/main/java/chat/rocket/android/settings/presentation/SettingsPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/settings/presentation/SettingsPresenter.kt
@@ -148,4 +148,6 @@ class SettingsPresenter @Inject constructor(
 
     fun toLicense(licenseUrl: String, licenseTitle: String) =
         navigator.toLicense(licenseUrl, licenseTitle)
+
+    fun recreateActivity() = navigator.recreateActivity()
 }

--- a/app/src/main/java/chat/rocket/android/settings/ui/SettingsFragment.kt
+++ b/app/src/main/java/chat/rocket/android/settings/ui/SettingsFragment.kt
@@ -132,7 +132,7 @@ class SettingsFragment : Fragment(), SettingsView, AppLanguageView {
 
     override fun updateLanguage(language: String, country: String?) {
         presenter.saveLocale(language, country)
-        activity?.recreate()
+        presenter.recreateActivity()
     }
 
     override fun invalidateToken(token: String) = invalidateFirebaseToken(token)


### PR DESCRIPTION
@RocketChat/android

Closes #2276
Closes #2323
Closes #2333

#### Changes:

By examining the logs produced in #2333, there were issues when the activity gets recreated after changing the language. It turns out that fragments get recreated as well on activity recreation, and thus `SettingsFragment` and possibly other fragments' `onCreate()` were called, causing memory leaks and the issues reported above, even though they were not visible. To overcome these issues, one could use [`setRetainInstance(true)`](https://developer.android.com/reference/android/app/Fragment.html#setRetainInstance(boolean)) to all the created fragments to prevent the fragments from calling `onDestroy()` and `onCreate()` when the activity is recreated, but since this method does not work for fragments added to the back stack, as mentioned in the Developers Reference, this solution was not possible. So all I did was just finishing `MainActivity` and recreating it on language change, and it solved all these issues.

#### GIF for the change:

As you can see, `NullPointerException` no longer occurs, and no crash occurs anymore when pressing back button after changing the language.

![language_change_fix](https://user-images.githubusercontent.com/20887574/58129752-c786b980-7c1a-11e9-82d3-b2f450de6b80.gif)