### PR TITLE
[FIX] Messages rendering out of order bug

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatroom/adapter/ChatRoomAdapter.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/adapter/ChatRoomAdapter.kt
@@ -173,6 +173,7 @@ class ChatRoomAdapter(
         notifyDataSetChanged()
     }
 
+    // FIXME What's 0,1 and 2 means for here?
     fun updateItem(message: BaseUiModel<*>): Int {
         val index = dataSet.indexOfLast { it.messageId == message.messageId }
         val indexOfNext = dataSet.indexOfFirst { it.messageId == message.messageId }

--- a/app/src/main/java/chat/rocket/android/chatroom/adapter/ChatRoomAdapter.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/adapter/ChatRoomAdapter.kt
@@ -173,7 +173,7 @@ class ChatRoomAdapter(
         notifyDataSetChanged()
     }
 
-    fun updateItem(message: BaseUiModel<*>): Boolean {
+    fun updateItem(message: BaseUiModel<*>): Int {
         val index = dataSet.indexOfLast { it.messageId == message.messageId }
         val indexOfNext = dataSet.indexOfFirst { it.messageId == message.messageId }
         Timber.d("index: $index")
@@ -184,7 +184,13 @@ class ChatRoomAdapter(
                     if (viewModel.nextDownStreamMessage == null) {
                         viewModel.reactions = message.reactions
                     }
-                    notifyItemChanged(ind)
+
+                    if (ind > 0 &&
+                        dataSet[ind].message.timestamp > dataSet[ind - 1].message.timestamp) {
+                        return 2
+                    } else {
+                        notifyItemChanged(ind)
+                    }
                 }
             }
             // Delete message only if current is a system message update, i.e.: Message Removed
@@ -192,9 +198,9 @@ class ChatRoomAdapter(
                 dataSet.removeAt(indexOfNext)
                 notifyItemRemoved(indexOfNext)
             }
-            return true
+            return 0
         }
-        return false
+        return 1
     }
 
     fun removeItem(messageId: String) {

--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
@@ -554,6 +554,7 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardListener, EmojiR
             if (message.isEmpty()) return@ui
 
             when (chatRoomAdapter.updateItem(message.last())) {
+                // FIXME: What's 0,1 and 2 means for here?
                 0 -> {
                     if (message.size > 1) {
                         chatRoomAdapter.prependData(listOf(message.first()))

--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
@@ -553,12 +553,21 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardListener, EmojiR
             // TODO - investigate WHY we get a empty list here
             if (message.isEmpty()) return@ui
 
-            if (chatRoomAdapter.updateItem(message.last())) {
-                if (message.size > 1) {
-                    chatRoomAdapter.prependData(listOf(message.first()))
+            when (chatRoomAdapter.updateItem(message.last())) {
+                0 -> {
+                    if (message.size > 1) {
+                        chatRoomAdapter.prependData(listOf(message.first()))
+                    }
                 }
-            } else {
-                showNewMessage(message, true)
+                1 -> showNewMessage(message, true)
+                2 -> {
+                    // Position of new sent message is wrong because of device local time is behind server time
+                    with(chatRoomAdapter) {
+                        removeItem(message.last().messageId)
+                        prependData(listOf(message.last()))
+                        notifyDataSetChanged()
+                    }
+                }
             }
             dismissEmojiKeyboard()
         }


### PR DESCRIPTION
@RocketChat/android

Closes #1677 
Closes https://github.com/RocketChat/Rocket.Chat.Android/issues/1926

#### Changes:

- When sending new msg set timestamp to `max` of (`(timestamp of last msg)+1` and `current time of local system`)

- When updated msg comes check its timestamp. If timestamp of msg is greater than next msg than update its postion