### PR TITLE
[FIX] SAML: Save username on login

### DIFF
--- a/app/src/main/java/chat/rocket/android/authentication/loginoptions/presentation/LoginOptionsPresenter.kt
+++ b/app/src/main/java/chat/rocket/android/authentication/loginoptions/presentation/LoginOptionsPresenter.kt
@@ -147,6 +147,7 @@ class LoginOptionsPresenter @Inject constructor(
                     )
                     localRepository.saveCurrentUser(url = currentServer, user = user)
                     saveCurrentServer.save(currentServer)
+                    localRepository.save(LocalRepository.CURRENT_USERNAME_KEY, username)
                     saveAccount(username)
                     saveToken(token)
                     analyticsManager.logLogin(loginMethod, true)


### PR DESCRIPTION
@RocketChat/android

Detailed description:
When using SAML login, the `username` is not saved into the local repository, which is a requirement for e.g. sendMessage [1] [2] [3] (a nullpointer occurs on [3])

#### Changes: [Add here what changes were made in this issue and if possible provide links.]
Fixes message send (and probably more) when using SAML login

[1] https://github.com/RocketChat/Rocket.Chat.Android/blob/1fd253cc9b8a92ff0d4b25b1d714653d113e9787/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomPresenter.kt#L360
[2] https://github.com/RocketChat/Rocket.Chat.Android/blob/391a93618f16208d84418594e72f9c122fed6676/app/src/main/java/chat/rocket/android/infrastructure/LocalRepository.kt#L38
[3] https://github.com/RocketChat/Rocket.Chat.Android/blob/1fd253cc9b8a92ff0d4b25b1d714653d113e9787/app/src/main/java/chat/rocket/android/chatroom/presentation/ChatRoomPresenter.kt#L370