### PR TITLE
[FIX] Null Pointer Exception

### DIFF
--- a/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
+++ b/app/src/main/java/chat/rocket/android/chatroom/ui/ChatRoomFragment.kt
@@ -746,8 +746,8 @@ class ChatRoomFragment : Fragment(), ChatRoomView, EmojiKeyboardListener, EmojiR
     }
 
     private fun setReactionButtonIcon(@DrawableRes drawableId: Int) {
-        button_add_reaction_or_show_keyboard.setImageResource(drawableId)
-        button_add_reaction_or_show_keyboard.tag = drawableId
+        button_add_reaction_or_show_keyboard?.setImageResource(drawableId)
+        button_add_reaction_or_show_keyboard?.tag = drawableId
     }
 
     override fun showFileSelection(filter: Array<String>?) {


### PR DESCRIPTION
Fixes a null pointer exception when setting the reaction or keyboard image.
Ref.: https://fabric.io/rocketchat3/android/apps/chat.rocket.android/issues/5c9b2d71f8b88c2963e1cf5f